### PR TITLE
Add script for batch PPTX generation and fix directives

### DIFF
--- a/scripts/Generate-SamplePptxSet.ps1
+++ b/scripts/Generate-SamplePptxSet.ps1
@@ -1,0 +1,81 @@
+param(
+    [string]$SamplesDirectory = "samples",
+    [string]$OutputDirectory = "artifacts/samples",
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Debug",
+    [string]$Template,
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-ThemeCssPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.FileInfo]$MarkdownFile
+    )
+
+    $candidateNames = @(
+        ("{0}.css" -f $MarkdownFile.BaseName),
+        ($(if ($MarkdownFile.BaseName.EndsWith("-css")) { "{0}.css" -f $MarkdownFile.BaseName.Substring(0, $MarkdownFile.BaseName.Length - 4) } else { $null }))
+    ) | Where-Object { $null -ne $_ } | Select-Object -Unique
+
+    foreach ($candidateName in $candidateNames) {
+        $candidatePath = Join-Path $MarkdownFile.DirectoryName $candidateName
+        if (Test-Path $candidatePath) {
+            return $candidatePath
+        }
+    }
+
+    return $null
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$generateScript = Join-Path $PSScriptRoot "Generate-LocalPptx.ps1"
+$resolvedSamplesDirectory = [System.IO.Path]::GetFullPath($SamplesDirectory, $repoRoot)
+$resolvedOutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory, $repoRoot)
+
+if (-not (Test-Path $resolvedSamplesDirectory)) {
+    throw "Samples directory was not found: $resolvedSamplesDirectory"
+}
+
+New-Item -ItemType Directory -Path $resolvedOutputDirectory -Force | Out-Null
+
+$sampleFiles = Get-ChildItem -Path $resolvedSamplesDirectory -File -Filter *.md |
+    Where-Object { $_.Name -ne "README.md" } |
+    Sort-Object Name
+
+if ($sampleFiles.Count -eq 0) {
+    throw "No sample Markdown files were found in '$resolvedSamplesDirectory'."
+}
+
+foreach ($sampleFile in $sampleFiles) {
+    $outputPath = Join-Path $resolvedOutputDirectory ("{0}.pptx" -f $sampleFile.BaseName)
+
+    if ((-not $Force) -and (Test-Path $outputPath)) {
+        Write-Host "Skipping '$($sampleFile.Name)' because '$outputPath' already exists. Use -Force to overwrite." -ForegroundColor Yellow
+        continue
+    }
+
+    $arguments = @{
+        InputMarkdown = $sampleFile.FullName
+        OutputPath = $outputPath
+        Configuration = $Configuration
+    }
+
+    $themeCssPath = Get-ThemeCssPath -MarkdownFile $sampleFile
+    if ($themeCssPath) {
+        $arguments.ThemeCss = $themeCssPath
+        Write-Host "Using theme CSS '$themeCssPath' for '$($sampleFile.Name)'." -ForegroundColor Cyan
+    }
+
+    if ($Template) {
+        $arguments.Template = [System.IO.Path]::GetFullPath($Template, $repoRoot)
+    }
+
+    Write-Host "Generating PPTX for '$($sampleFile.Name)'..." -ForegroundColor Cyan
+    & $generateScript @arguments
+}
+
+Write-Host "Finished generating sample PPTX files in '$resolvedOutputDirectory'." -ForegroundColor Green

--- a/scripts/Invoke-PptxSmokeTest.ps1
+++ b/scripts/Invoke-PptxSmokeTest.ps1
@@ -183,7 +183,19 @@ function Test-OpenXmlPackage {
 	if ($validationErrors.Count -gt 0) {
 		Write-Host "Open XML validation failed:" -ForegroundColor Red
 		foreach ($validationError in $validationErrors) {
-			Write-Host ("- {0} at {1}" -f $validationError.Description, $validationError.Path.XPath)
+			$pathText = if ($validationError.Path) {
+				if ($validationError.Path | Get-Member -Name XPath -ErrorAction SilentlyContinue) {
+					$validationError.Path.XPath
+				}
+				else {
+					$validationError.Path.ToString()
+				}
+			}
+			else {
+				"<unknown path>"
+			}
+
+			Write-Host ("- {0} at {1}" -f $validationError.Description, $pathText)
 		}
 
 		throw "Open XML validation found $($validationErrors.Count) error(s)."

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,15 @@ Generate a PPTX with the local CLI project instead of the published `dnx` tool.
 pwsh ./scripts/Generate-LocalPptx.ps1 -InputMarkdown samples/01-minimal.md -OutputPath artifacts/samples/01-minimal-scripted.pptx
 ```
 
+### `Generate-SamplePptxSet.ps1`
+
+Generate PPTX output for each sample deck in `samples/`, writing results to `artifacts/samples/`. The script skips `samples/README.md` and will auto-pick a companion CSS file such as `samples/03-theme.css` for `samples/03-theme-css.md`.
+
+```powershell
+pwsh ./scripts/Generate-SamplePptxSet.ps1
+pwsh ./scripts/Generate-SamplePptxSet.ps1 -Configuration Release -Force
+```
+
 ### `Expand-Pptx.ps1`
 
 Expand a `.pptx` package into a normal directory for inspection.

--- a/src/MarpToPptx.Pptx/Rendering/OpenXmlPptxRenderer.cs
+++ b/src/MarpToPptx.Pptx/Rendering/OpenXmlPptxRenderer.cs
@@ -1068,7 +1068,7 @@ public sealed class OpenXmlPptxRenderer
             return "000000";
         }
 
-        var trimmed = value.Trim();
+        var trimmed = value.Trim().Trim('"', '\'');
         if (trimmed.StartsWith('#'))
         {
             trimmed = trimmed[1..];
@@ -1090,6 +1090,7 @@ public sealed class OpenXmlPptxRenderer
             ".gif" => "image/gif",
             ".bmp" => "image/bmp",
             ".tif" or ".tiff" => "image/tiff",
+            ".svg" => "image/svg+xml",
             _ => "image/png",
         };
 

--- a/tests/MarpToPptx.Tests/PptxRendererTests.cs
+++ b/tests/MarpToPptx.Tests/PptxRendererTests.cs
@@ -77,4 +77,51 @@ public class PptxRendererTests
         var slideRelationships = slideRelationshipsReader.ReadToEnd();
         Assert.Contains("../slideLayouts/slideLayout2.xml", slideRelationships);
     }
+
+    [Fact]
+    public void Renderer_AcceptsQuotedFrontMatterColorsAndSvgBackgrounds()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "MarpToPptx.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        var markdownPath = Path.Combine(tempRoot, "deck.md");
+        var svgPath = Path.Combine(tempRoot, "accent-wave.svg");
+        var outputPath = Path.Combine(tempRoot, "deck.pptx");
+
+        File.WriteAllText(svgPath, """
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+          <rect width="100" height="100" fill="#102A43" />
+          <path d="M0 70 C 20 40, 40 40, 60 70 S 100 100, 100 60 L100 100 L0 100 Z" fill="#F7C948" />
+        </svg>
+        """);
+
+        File.WriteAllText(markdownPath, """
+        ---
+        theme: gaia
+        backgroundColor: "#F7F3E8"
+        ---
+
+        # Quoted Color
+
+        ---
+
+        <!-- backgroundImage: url(accent-wave.svg) -->
+        # Svg Background
+        """);
+
+        var compiler = new MarpCompiler();
+        var deck = compiler.Compile(File.ReadAllText(markdownPath), markdownPath);
+
+        var renderer = new OpenXmlPptxRenderer();
+        renderer.Render(deck, outputPath, new PptxRenderOptions { SourceDirectory = tempRoot });
+
+        using var document = PresentationDocument.Open(outputPath, false);
+        var validationErrors = new OpenXmlValidator().Validate(document).ToList();
+        Assert.Empty(validationErrors);
+
+        using var archive = ZipFile.OpenRead(outputPath);
+        using var contentTypesReader = new StreamReader(archive.GetEntry("[Content_Types].xml")!.Open());
+        var contentTypes = contentTypesReader.ReadToEnd();
+        Assert.Contains("image/svg+xml", contentTypes);
+    }
 }


### PR DESCRIPTION
This pull request introduces a new PowerShell script to automate generating PPTX files from Markdown samples, improves documentation, and adds support for quoted color values and SVG images in presentation rendering. It also enhances testing to ensure these new features work as expected.