### PR TITLE
Add OpenXmlValidator project

### DIFF
--- a/MarpToPptx.slnx
+++ b/MarpToPptx.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/MarpToPptx.Cli/MarpToPptx.Cli.csproj" />
     <Project Path="src/MarpToPptx.Core/MarpToPptx.Core.csproj" />
+    <Project Path="src/MarpToPptx.OpenXmlValidator/MarpToPptx.OpenXmlValidator.csproj" />
     <Project Path="src/MarpToPptx.Pptx/MarpToPptx.Pptx.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For integrating `MarpToPptx` into a VS Code authoring workflow in a content repo
 - `src/MarpToPptx.Core`: semantic slide model, Markdown parsing, theme parsing, layout planning
 - `src/MarpToPptx.Pptx`: Open XML PPTX rendering and template-aware presentation generation
 - `src/MarpToPptx.Cli`: `marp2pptx` command-line entrypoint
+- `src/MarpToPptx.OpenXmlValidator`: small .NET validation helper used by smoke tests and CI
 - `scripts/`: PowerShell helpers for local generation, smoke tests, package inspection, and PowerPoint troubleshooting
 - `tests/MarpToPptx.Tests`: xUnit v3 tests running on Microsoft Testing Platform
 - `samples/`: Marp-style sample decks for smoke tests, feature coverage, theme parsing, and compatibility-gap repros

--- a/scripts/Invoke-PptxSmokeTest.ps1
+++ b/scripts/Invoke-PptxSmokeTest.ps1
@@ -16,192 +16,40 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-$script:OpenXmlAssemblies = @()
-
-function Get-OpenXmlType {
+function Invoke-OpenXmlValidation {
 	param(
 		[Parameter(Mandatory = $true)]
-		[string]$TypeName
+		[string]$PptxPath,
+
+		[Parameter(Mandatory = $true)]
+		[string]$Configuration,
+
+		[Parameter(Mandatory = $true)]
+		[string]$RepositoryRoot
 	)
 
-	foreach ($assembly in $script:OpenXmlAssemblies) {
-		$type = $assembly.GetType($TypeName, $false)
-		if ($null -ne $type) {
-			return $type
-		}
-	}
-
-	throw "Unable to find type [$TypeName] in the loaded Open XML assemblies."
-}
-
-function Get-PackageAssemblyPath {
-	param(
-		[Parameter(Mandatory = $true)]
-		[hashtable]$AssetsData,
-
-		[Parameter(Mandatory = $true)]
-		[string]$PackageId,
-
-		[Parameter(Mandatory = $true)]
-		[string]$FileName,
-
-		[Parameter(Mandatory = $true)]
-		[string]$NuGetPackagesRoot
-	)
-
-	$libraryEntry = $AssetsData["libraries"].GetEnumerator() |
-		Where-Object { $_.Key -like "$PackageId/*" } |
-		Select-Object -First 1
-
-	if ($null -eq $libraryEntry) {
-		throw "Unable to find package '$PackageId' in project.assets.json."
-	}
-
-	$packageFiles = @($libraryEntry.Value["files"])
-	$preferredFrameworks = @()
-	$runtimeVersionMajor = [System.Environment]::Version.Major
-
-	if ($runtimeVersionMajor -ge 10) {
-		$preferredFrameworks += "net10.0"
-	}
-
-	if ($runtimeVersionMajor -ge 8) {
-		$preferredFrameworks += "net8.0"
-	}
-
-	if ($runtimeVersionMajor -ge 6) {
-		$preferredFrameworks += "net6.0"
-	}
-
-	$preferredFrameworks += "netstandard2.0"
-
-	$relativeAssemblyPath = $null
-	foreach ($framework in $preferredFrameworks | Select-Object -Unique) {
-		$candidatePath = "lib/$framework/$FileName"
-		if ($packageFiles -contains $candidatePath) {
-			$relativeAssemblyPath = $candidatePath
-			break
-		}
-	}
-
-	if ($null -eq $relativeAssemblyPath) {
-		throw "Unable to find a PowerShell-compatible runtime assembly '$FileName' for package '$PackageId'."
-	}
-
-	return Join-Path (Join-Path $NuGetPackagesRoot $libraryEntry.Value["path"]) $relativeAssemblyPath
-}
-
-function Import-OpenXmlValidationAssemblies {
-	param(
-		[Parameter(Mandatory = $true)]
-		[string]$CliOutputDirectory
-	)
-
-	$cliProjectDirectory = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $CliOutputDirectory))
-	$assetsFilePath = Join-Path (Join-Path $cliProjectDirectory "obj") "project.assets.json"
-	if (-not (Test-Path $assetsFilePath)) {
-		throw "Unable to locate project.assets.json at '$assetsFilePath'."
-	}
-
-	$nuGetPackagesRoot = if ($env:NUGET_PACKAGES) {
-		$env:NUGET_PACKAGES
-	}
-	elseif ($HOME) {
-		Join-Path $HOME ".nuget/packages"
-	}
-	else {
-		throw "Unable to determine the NuGet global-packages directory."
-	}
-
-	$assetsData = Get-Content -Path $assetsFilePath -Raw | ConvertFrom-Json -AsHashtable
-	$assemblyPaths = @(
-		(Get-PackageAssemblyPath -AssetsData $assetsData -PackageId "System.IO.Packaging" -FileName "System.IO.Packaging.dll" -NuGetPackagesRoot $nuGetPackagesRoot),
-		(Get-PackageAssemblyPath -AssetsData $assetsData -PackageId "DocumentFormat.OpenXml.Framework" -FileName "DocumentFormat.OpenXml.Framework.dll" -NuGetPackagesRoot $nuGetPackagesRoot),
-		(Get-PackageAssemblyPath -AssetsData $assetsData -PackageId "DocumentFormat.OpenXml" -FileName "DocumentFormat.OpenXml.dll" -NuGetPackagesRoot $nuGetPackagesRoot)
-	)
-
-	$loadedAssemblies = @()
-
-	foreach ($assemblyPath in $assemblyPaths) {
-		if (-not (Test-Path $assemblyPath)) {
-			throw "Required validation assembly was not found: $assemblyPath"
-		}
-
-		$assemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($assemblyPath)
-		$assembly = [AppDomain]::CurrentDomain.GetAssemblies() |
-			Where-Object { $_.FullName -eq $assemblyName.FullName } |
-			Select-Object -First 1
-		if ($null -eq $assembly) {
-			$tempDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ("MarpToPptx-openxml-{0}" -f ([System.Guid]::NewGuid().ToString("N")))
-			New-Item -ItemType Directory -Path $tempDirectory -Force | Out-Null
-			$tempAssemblyPath = Join-Path $tempDirectory ([System.IO.Path]::GetFileName($assemblyPath))
-			Copy-Item -Path $assemblyPath -Destination $tempAssemblyPath -Force
-			$assembly = [System.Reflection.Assembly]::LoadFrom($tempAssemblyPath)
-		}
-
-		$loadedAssemblies += $assembly
-	}
-
-	$script:OpenXmlAssemblies = $loadedAssemblies
-}
-
-function Test-OpenXmlPackage {
-	param(
-		[Parameter(Mandatory = $true)]
-		[string]$PptxPath
-	)
-
-	$validationErrors = @()
-	$document = $null
-	$presentationDocumentType = Get-OpenXmlType -TypeName "DocumentFormat.OpenXml.Packaging.PresentationDocument"
-	$openXmlValidatorType = Get-OpenXmlType -TypeName "DocumentFormat.OpenXml.Validation.OpenXmlValidator"
-	$openMethod = $presentationDocumentType.GetMethods() |
-		Where-Object {
-			$parameters = $_.GetParameters()
-			$_.Name -eq "Open" -and
-			$parameters.Count -eq 2 -and
-			$parameters[0].ParameterType -eq [string] -and
-			$parameters[1].ParameterType -eq [bool]
-		} |
-		Select-Object -First 1
-
-	if ($null -eq $openMethod) {
-		throw "Unable to find PresentationDocument.Open(string, bool)."
-	}
-
+	Push-Location $RepositoryRoot
 	try {
-		$document = $openMethod.Invoke($null, @($PptxPath, $false))
-		$validator = [System.Activator]::CreateInstance($openXmlValidatorType)
-		$validationErrors = @($validator.Validate($document))
+		$arguments = @(
+			"run"
+			"--project"
+			"src/MarpToPptx.OpenXmlValidator"
+			"-c"
+			$Configuration
+			"--"
+			$PptxPath
+		)
+
+		Write-Host ("dotnet {0}" -f ($arguments -join " "))
+		& dotnet @arguments
+
+		if ($LASTEXITCODE -ne 0) {
+			throw "Open XML validation helper failed with exit code $LASTEXITCODE"
+		}
 	}
 	finally {
-		if ($document) {
-			$document.Dispose()
-		}
+		Pop-Location
 	}
-
-	if ($validationErrors.Count -gt 0) {
-		Write-Host "Open XML validation failed:" -ForegroundColor Red
-		foreach ($validationError in $validationErrors) {
-			$pathText = if ($validationError.Path) {
-				if ($validationError.Path | Get-Member -Name XPath -ErrorAction SilentlyContinue) {
-					$validationError.Path.XPath
-				}
-				else {
-					$validationError.Path.ToString()
-				}
-			}
-			else {
-				"<unknown path>"
-			}
-
-			Write-Host ("- {0} at {1}" -f $validationError.Description, $pathText)
-		}
-
-		throw "Open XML validation found $($validationErrors.Count) error(s)."
-	}
-
-	Write-Host "Open XML validation passed." -ForegroundColor Green
 }
 
 function Test-PowerPointAutomationAvailable {
@@ -263,14 +111,8 @@ if ($Template) {
 
 & $generateScript @generateArguments
 
-$cliOutputDirectory = Join-Path (Join-Path (Join-Path (Join-Path $repoRoot "src") "MarpToPptx.Cli") "bin") (Join-Path $Configuration "net10.0")
-if (-not (Test-Path $cliOutputDirectory)) {
-	throw "CLI output directory was not found after generation: $cliOutputDirectory"
-}
-
 Write-Host "Step 2: Validate the generated package with Open XML SDK." -ForegroundColor Cyan
-Import-OpenXmlValidationAssemblies -CliOutputDirectory $cliOutputDirectory
-Test-OpenXmlPackage -PptxPath $resolvedOutputPath
+Invoke-OpenXmlValidation -PptxPath $resolvedOutputPath -Configuration $Configuration -RepositoryRoot $repoRoot
 
 if (-not $SkipPowerPoint) {
 	Write-Host "Step 3: Open the package in PowerPoint." -ForegroundColor Cyan

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,7 +48,7 @@ pwsh ./scripts/Compare-PptxStructure.ps1 -PathA artifacts/samples/01-minimal-scr
 
 ### `Invoke-PptxSmokeTest.ps1`
 
-Run the main local PPTX smoke-test flow in one command: generate with the local CLI project, validate with the Open XML SDK, and then open the result in PowerPoint.
+Run the main local PPTX smoke-test flow in one command: generate with the local CLI project, validate with the .NET Open XML helper, and then open the result in PowerPoint.
 
 ```powershell
 pwsh ./scripts/Invoke-PptxSmokeTest.ps1 -InputMarkdown samples/01-minimal.md
@@ -62,4 +62,4 @@ pwsh ./scripts/Invoke-PptxSmokeTest.ps1 -InputMarkdown samples/01-minimal.md -Ci
 - `Test-PowerPointOpen.ps1` requires Microsoft PowerPoint to be installed and available through COM interop.
 - `Generate-LocalPptx.ps1` is the preferred path for renderer debugging because it executes the current workspace code.
 - `Invoke-PptxSmokeTest.ps1` is the quickest end-to-end check before or after renderer/package changes.
-- `Invoke-PptxSmokeTest.ps1 -CiSafe` keeps the PowerPoint step when COM automation is available, but automatically falls back to generation plus Open XML validation on CI agents or other environments without PowerPoint.
+- `Invoke-PptxSmokeTest.ps1 -CiSafe` keeps the PowerPoint step when COM automation is available, but automatically falls back to generation plus .NET-hosted Open XML validation on CI agents or other environments without PowerPoint.

--- a/src/MarpToPptx.OpenXmlValidator/MarpToPptx.OpenXmlValidator.csproj
+++ b/src/MarpToPptx.OpenXmlValidator/MarpToPptx.OpenXmlValidator.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\MarpToPptx.Pptx\MarpToPptx.Pptx.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/MarpToPptx.OpenXmlValidator/Program.cs
+++ b/src/MarpToPptx.OpenXmlValidator/Program.cs
@@ -1,0 +1,45 @@
+using MarpToPptx.Pptx.Validation;
+
+if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+{
+    Console.Error.WriteLine("Usage: dotnet run --project src/MarpToPptx.OpenXmlValidator -- <path-to-pptx>");
+    return 1;
+}
+
+var pptxPath = Path.GetFullPath(args[0]);
+if (!File.Exists(pptxPath))
+{
+    Console.Error.WriteLine($"PPTX file was not found: {pptxPath}");
+    return 1;
+}
+
+try
+{
+    var validator = new OpenXmlPackageValidator();
+    var validationErrors = validator.Validate(pptxPath);
+
+    if (validationErrors.Count == 0)
+    {
+        Console.WriteLine($"Open XML validation passed for '{pptxPath}'.");
+        return 0;
+    }
+
+    Console.Error.WriteLine($"Open XML validation failed for '{pptxPath}' with {validationErrors.Count} error(s):");
+    foreach (var validationError in validationErrors)
+    {
+        Console.Error.WriteLine($"- {validationError.Description}");
+        Console.Error.WriteLine($"  Path: {validationError.Path}");
+
+        if (!string.IsNullOrWhiteSpace(validationError.PartUri))
+        {
+            Console.Error.WriteLine($"  Part: {validationError.PartUri}");
+        }
+    }
+
+    return 2;
+}
+catch (Exception exception)
+{
+    Console.Error.WriteLine($"Open XML validation failed for '{pptxPath}': {exception.Message}");
+    return 1;
+}

--- a/src/MarpToPptx.Pptx/Validation/OpenXmlPackageValidationError.cs
+++ b/src/MarpToPptx.Pptx/Validation/OpenXmlPackageValidationError.cs
@@ -1,0 +1,6 @@
+namespace MarpToPptx.Pptx.Validation;
+
+public sealed record OpenXmlPackageValidationError(
+    string Description,
+    string Path,
+    string? PartUri);

--- a/src/MarpToPptx.Pptx/Validation/OpenXmlPackageValidator.cs
+++ b/src/MarpToPptx.Pptx/Validation/OpenXmlPackageValidator.cs
@@ -1,0 +1,28 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+
+namespace MarpToPptx.Pptx.Validation;
+
+public sealed class OpenXmlPackageValidator
+{
+    public IReadOnlyList<OpenXmlPackageValidationError> Validate(string pptxPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pptxPath);
+
+        using var document = PresentationDocument.Open(pptxPath, false);
+        return Validate(document);
+    }
+
+    public IReadOnlyList<OpenXmlPackageValidationError> Validate(PresentationDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        return new OpenXmlValidator()
+            .Validate(document)
+            .Select(error => new OpenXmlPackageValidationError(
+                error.Description ?? "Open XML validation error.",
+                error.Path?.ToString() ?? "<unknown path>",
+                error.Part?.Uri?.ToString()))
+            .ToArray();
+    }
+}

--- a/tests/MarpToPptx.Tests/PptxRendererTests.cs
+++ b/tests/MarpToPptx.Tests/PptxRendererTests.cs
@@ -1,7 +1,7 @@
 using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Validation;
 using MarpToPptx.Core;
 using MarpToPptx.Pptx.Rendering;
+using MarpToPptx.Pptx.Validation;
 using System.IO.Compression;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
@@ -54,12 +54,15 @@ public class PptxRendererTests
         Assert.Equal(2, presentationPart.SlideMasterParts.Single().SlideLayoutParts.Count());
 
         var slideParts = presentationPart.SlideParts.ToArray();
+        Assert.Equal(2, slideParts.Length);
         Assert.All(slideParts, slidePart => Assert.Equal("/ppt/slideLayouts/slideLayout2.xml", slidePart.SlideLayoutPart?.Uri.ToString()));
-        Assert.Contains("Title Slide", slideParts[0].Slide.Descendants<A.Text>().Select(text => text.Text));
-        Assert.Contains("Intro paragraph.", slideParts[0].Slide.Descendants<A.Text>().Select(text => text.Text));
-        Assert.Single(slideParts[1].Slide.Descendants<P.Picture>());
+        Assert.NotNull(slideParts[0].Slide);
+        Assert.NotNull(slideParts[1].Slide);
+        Assert.Contains("Title Slide", slideParts[0].Slide!.Descendants<A.Text>().Select(text => text.Text));
+        Assert.Contains("Intro paragraph.", slideParts[0].Slide!.Descendants<A.Text>().Select(text => text.Text));
+        Assert.Single(slideParts[1].Slide!.Descendants<P.Picture>());
 
-        var validationErrors = new OpenXmlValidator().Validate(document).ToList();
+        var validationErrors = new OpenXmlPackageValidator().Validate(document);
         Assert.Empty(validationErrors);
 
         using var archive = ZipFile.OpenRead(outputPath);
@@ -116,7 +119,7 @@ public class PptxRendererTests
         renderer.Render(deck, outputPath, new PptxRenderOptions { SourceDirectory = tempRoot });
 
         using var document = PresentationDocument.Open(outputPath, false);
-        var validationErrors = new OpenXmlValidator().Validate(document).ToList();
+        var validationErrors = new OpenXmlPackageValidator().Validate(document);
         Assert.Empty(validationErrors);
 
         using var archive = ZipFile.OpenRead(outputPath);


### PR DESCRIPTION
This pull request introduces a new .NET-based Open XML validation helper to the project, streamlining how PPTX files are validated both locally and in CI. The PowerShell smoke test script now delegates validation to this new helper, and the validation logic is encapsulated in the codebase for easier reuse and maintenance. Documentation and tests have been updated to reflect these changes.