### PR TITLE
Add golden package tests for PPTX rendering and SVG backgrounds

### DIFF
--- a/doc/pptx-compatibility-notes.md
+++ b/doc/pptx-compatibility-notes.md
@@ -180,6 +180,14 @@ dotnet test --project tests/MarpToPptx.Tests/MarpToPptx.Tests.csproj -c Release 
 
 The renderer tests cover both semantic content and key package-structure regressions.
 
+When package-shape behavior changes intentionally, regenerate the checked-in golden baselines with:
+
+```bash
+UPDATE_GOLDEN_PACKAGES=1 dotnet test --project tests/MarpToPptx.Tests/MarpToPptx.Tests.csproj -c Release --no-restore
+```
+
+The fixture files live under `tests/MarpToPptx.Tests/Fixtures/` and are limited to normalized package inventory plus relationship/content-type XML so they stay focused on stable compatibility invariants.
+
 ### 2. Generate a sample with the local project
 
 Use the local CLI project when validating renderer changes:

--- a/tests/MarpToPptx.Tests/Fixtures/minimal-deck.package.json
+++ b/tests/MarpToPptx.Tests/Fixtures/minimal-deck.package.json
@@ -1,0 +1,36 @@
+{
+  "Entries": [
+    "[Content_Types].xml",
+    "_rels/.rels",
+    "docProps/app.xml",
+    "docProps/core.xml",
+    "ppt/_rels/presentation.xml.rels",
+    "ppt/media/image.png",
+    "ppt/presProps.xml",
+    "ppt/presentation.xml",
+    "ppt/slideLayouts/_rels/slideLayout1.xml.rels",
+    "ppt/slideLayouts/_rels/slideLayout2.xml.rels",
+    "ppt/slideLayouts/slideLayout1.xml",
+    "ppt/slideLayouts/slideLayout2.xml",
+    "ppt/slideMasters/_rels/slideMaster1.xml.rels",
+    "ppt/slideMasters/slideMaster1.xml",
+    "ppt/slides/_rels/slide1.xml.rels",
+    "ppt/slides/_rels/slide2.xml.rels",
+    "ppt/slides/slide1.xml",
+    "ppt/slides/slide2.xml",
+    "ppt/tableStyles.xml",
+    "ppt/theme/theme1.xml",
+    "ppt/viewProps.xml"
+  ],
+  "NormalizedXmlParts": {
+    "[Content_Types].xml": "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\"><Default ContentType=\"application/xml\" Extension=\"xml\" /><Default ContentType=\"image/png\" Extension=\"png\" /><Default ContentType=\"application/vnd.openxmlformats-package.relationships+xml\" Extension=\"rels\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml\" PartName=\"/ppt/slideMasters/slideMaster1.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml\" PartName=\"/ppt/slideLayouts/slideLayout1.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml\" PartName=\"/ppt/slideLayouts/slideLayout2.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.theme+xml\" PartName=\"/ppt/theme/theme1.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.presProps+xml\" PartName=\"/ppt/presProps.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.viewProps+xml\" PartName=\"/ppt/viewProps.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.tableStyles+xml\" PartName=\"/ppt/tableStyles.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.slide+xml\" PartName=\"/ppt/slides/slide1.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.slide+xml\" PartName=\"/ppt/slides/slide2.xml\" /><Override ContentType=\"application/vnd.openxmlformats-package.core-properties+xml\" PartName=\"/docProps/core.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.extended-properties+xml\" PartName=\"/docProps/app.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml\" PartName=\"/ppt/presentation.xml\" /></Types>",
+    "_rels/.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"ppt/presentation.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" /><Relationship Id=\"rId2\" Target=\"docProps/core.xml\" Type=\"http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties\" /><Relationship Id=\"rId3\" Target=\"docProps/app.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties\" /></Relationships>",
+    "ppt/_rels/presentation.xml.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"slideMasters/slideMaster1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster\" /><Relationship Id=\"rId2\" Target=\"theme/theme1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme\" /><Relationship Id=\"rId3\" Target=\"presProps.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/presProps\" /><Relationship Id=\"rId4\" Target=\"viewProps.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/viewProps\" /><Relationship Id=\"rId5\" Target=\"tableStyles.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/tableStyles\" /><Relationship Id=\"rId6\" Target=\"slides/slide1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide\" /><Relationship Id=\"rId7\" Target=\"slides/slide2.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide\" /></Relationships>",
+    "ppt/presentation.xml": "<p:presentation xmlns:p=\"http://schemas.openxmlformats.org/presentationml/2006/main\"><p:sldMasterIdLst><p:sldMasterId id=\"2147483648\" r:id=\"rId1\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" /></p:sldMasterIdLst><p:sldIdLst><p:sldId id=\"256\" r:id=\"rId2\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" /><p:sldId id=\"257\" r:id=\"rId3\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" /></p:sldIdLst><p:sldSz cx=\"12192000\" cy=\"6858000\" type=\"screen16x9\" /><p:notesSz cx=\"6858000\" cy=\"9144000\" /><p:defaultTextStyle /></p:presentation>",
+    "ppt/slideLayouts/_rels/slideLayout1.xml.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"../slideMasters/slideMaster1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster\" /></Relationships>",
+    "ppt/slideLayouts/_rels/slideLayout2.xml.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"../slideMasters/slideMaster1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster\" /></Relationships>",
+    "ppt/slideMasters/_rels/slideMaster1.xml.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"../slideLayouts/slideLayout1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout\" /><Relationship Id=\"rId2\" Target=\"../slideLayouts/slideLayout2.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout\" /><Relationship Id=\"rId3\" Target=\"../theme/theme1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme\" /></Relationships>",
+    "ppt/slides/_rels/slide1.xml.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"../slideLayouts/slideLayout2.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout\" /></Relationships>",
+    "ppt/slides/_rels/slide2.xml.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"../slideLayouts/slideLayout2.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout\" /><Relationship Id=\"rId2\" Target=\"../media/image.png\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\" /></Relationships>"
+  }
+}

--- a/tests/MarpToPptx.Tests/Fixtures/svg-background.package.json
+++ b/tests/MarpToPptx.Tests/Fixtures/svg-background.package.json
@@ -1,0 +1,36 @@
+{
+  "Entries": [
+    "[Content_Types].xml",
+    "_rels/.rels",
+    "docProps/app.xml",
+    "docProps/core.xml",
+    "ppt/_rels/presentation.xml.rels",
+    "ppt/media/image.svg",
+    "ppt/presProps.xml",
+    "ppt/presentation.xml",
+    "ppt/slideLayouts/_rels/slideLayout1.xml.rels",
+    "ppt/slideLayouts/_rels/slideLayout2.xml.rels",
+    "ppt/slideLayouts/slideLayout1.xml",
+    "ppt/slideLayouts/slideLayout2.xml",
+    "ppt/slideMasters/_rels/slideMaster1.xml.rels",
+    "ppt/slideMasters/slideMaster1.xml",
+    "ppt/slides/_rels/slide1.xml.rels",
+    "ppt/slides/_rels/slide2.xml.rels",
+    "ppt/slides/slide1.xml",
+    "ppt/slides/slide2.xml",
+    "ppt/tableStyles.xml",
+    "ppt/theme/theme1.xml",
+    "ppt/viewProps.xml"
+  ],
+  "NormalizedXmlParts": {
+    "[Content_Types].xml": "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\"><Default ContentType=\"application/xml\" Extension=\"xml\" /><Default ContentType=\"image/svg+xml\" Extension=\"svg\" /><Default ContentType=\"application/vnd.openxmlformats-package.relationships+xml\" Extension=\"rels\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml\" PartName=\"/ppt/slideMasters/slideMaster1.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml\" PartName=\"/ppt/slideLayouts/slideLayout1.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml\" PartName=\"/ppt/slideLayouts/slideLayout2.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.theme+xml\" PartName=\"/ppt/theme/theme1.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.presProps+xml\" PartName=\"/ppt/presProps.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.viewProps+xml\" PartName=\"/ppt/viewProps.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.tableStyles+xml\" PartName=\"/ppt/tableStyles.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.slide+xml\" PartName=\"/ppt/slides/slide1.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.slide+xml\" PartName=\"/ppt/slides/slide2.xml\" /><Override ContentType=\"application/vnd.openxmlformats-package.core-properties+xml\" PartName=\"/docProps/core.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.extended-properties+xml\" PartName=\"/docProps/app.xml\" /><Override ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml\" PartName=\"/ppt/presentation.xml\" /></Types>",
+    "_rels/.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"ppt/presentation.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" /><Relationship Id=\"rId2\" Target=\"docProps/core.xml\" Type=\"http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties\" /><Relationship Id=\"rId3\" Target=\"docProps/app.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties\" /></Relationships>",
+    "ppt/_rels/presentation.xml.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"slideMasters/slideMaster1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster\" /><Relationship Id=\"rId2\" Target=\"theme/theme1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme\" /><Relationship Id=\"rId3\" Target=\"presProps.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/presProps\" /><Relationship Id=\"rId4\" Target=\"viewProps.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/viewProps\" /><Relationship Id=\"rId5\" Target=\"tableStyles.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/tableStyles\" /><Relationship Id=\"rId6\" Target=\"slides/slide1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide\" /><Relationship Id=\"rId7\" Target=\"slides/slide2.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide\" /></Relationships>",
+    "ppt/presentation.xml": "<p:presentation xmlns:p=\"http://schemas.openxmlformats.org/presentationml/2006/main\"><p:sldMasterIdLst><p:sldMasterId id=\"2147483648\" r:id=\"rId1\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" /></p:sldMasterIdLst><p:sldIdLst><p:sldId id=\"256\" r:id=\"rId2\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" /><p:sldId id=\"257\" r:id=\"rId3\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" /></p:sldIdLst><p:sldSz cx=\"12192000\" cy=\"6858000\" type=\"screen16x9\" /><p:notesSz cx=\"6858000\" cy=\"9144000\" /><p:defaultTextStyle /></p:presentation>",
+    "ppt/slideLayouts/_rels/slideLayout1.xml.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"../slideMasters/slideMaster1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster\" /></Relationships>",
+    "ppt/slideLayouts/_rels/slideLayout2.xml.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"../slideMasters/slideMaster1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster\" /></Relationships>",
+    "ppt/slideMasters/_rels/slideMaster1.xml.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"../slideLayouts/slideLayout1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout\" /><Relationship Id=\"rId2\" Target=\"../slideLayouts/slideLayout2.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout\" /><Relationship Id=\"rId3\" Target=\"../theme/theme1.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme\" /></Relationships>",
+    "ppt/slides/_rels/slide1.xml.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"../slideLayouts/slideLayout2.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout\" /></Relationships>",
+    "ppt/slides/_rels/slide2.xml.rels": "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Target=\"../slideLayouts/slideLayout2.xml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout\" /><Relationship Id=\"rId2\" Target=\"../media/image.svg\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\" /></Relationships>"
+  }
+}

--- a/tests/MarpToPptx.Tests/PptxGoldenPackage.cs
+++ b/tests/MarpToPptx.Tests/PptxGoldenPackage.cs
@@ -1,0 +1,153 @@
+using System.IO.Compression;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace MarpToPptx.Tests;
+
+internal static class PptxGoldenPackage
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        WriteIndented = true,
+    };
+
+    private static readonly string[] FixedXmlPaths =
+    [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "ppt/presentation.xml",
+        "ppt/_rels/presentation.xml.rels",
+        "ppt/slideMasters/_rels/slideMaster1.xml.rels",
+    ];
+
+    public static void AssertMatchesFixture(string pptxPath, string fixtureFileName)
+    {
+        var actual = CreateSnapshot(pptxPath);
+        var actualJson = Serialize(actual);
+        var fixturePath = GetFixturePath(fixtureFileName);
+
+        if (ShouldUpdateFixtures())
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(fixturePath)!);
+            File.WriteAllText(fixturePath, actualJson);
+        }
+
+        Assert.True(File.Exists(fixturePath), $"Golden fixture '{fixtureFileName}' was not found at '{fixturePath}'. Set UPDATE_GOLDEN_PACKAGES=1 and rerun the tests to create it intentionally.");
+
+        var expectedJson = File.ReadAllText(fixturePath);
+        Assert.Equal(expectedJson, actualJson);
+    }
+
+    private static PptxPackageSnapshot CreateSnapshot(string pptxPath)
+    {
+        using var archive = ZipFile.OpenRead(pptxPath);
+        var entryPaths = archive.Entries
+            .Where(entry => !string.IsNullOrEmpty(entry.Name))
+            .Select(entry => entry.FullName.Replace('\\', '/'))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        var xmlPaths = FixedXmlPaths
+            .Concat(entryPaths.Where(path => path.StartsWith("ppt/slideLayouts/_rels/", StringComparison.Ordinal) && path.EndsWith(".rels", StringComparison.Ordinal)))
+            .Concat(entryPaths.Where(path => path.StartsWith("ppt/slides/_rels/", StringComparison.Ordinal) && path.EndsWith(".rels", StringComparison.Ordinal)))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        var normalizedXmlParts = xmlPaths.ToDictionary(
+            path => path,
+            path => NormalizeXml(ReadArchiveEntry(archive, path)),
+            StringComparer.Ordinal);
+
+        return new PptxPackageSnapshot(entryPaths, normalizedXmlParts);
+    }
+
+    private static string ReadArchiveEntry(ZipArchive archive, string path)
+    {
+        using var stream = archive.GetEntry(path)?.Open()
+            ?? throw new InvalidOperationException($"Expected archive entry '{path}' was not found.");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    private static string NormalizeXml(string xml)
+    {
+        var document = XDocument.Parse(xml, LoadOptions.None);
+        if (document.Root is null)
+        {
+            return string.Empty;
+        }
+
+        NormalizeRelationshipIds(document.Root);
+        NormalizeElement(document.Root);
+        return document.ToString(SaveOptions.DisableFormatting);
+    }
+
+    private static void NormalizeRelationshipIds(XElement root)
+    {
+        if (!string.Equals(root.Name.LocalName, "Relationships", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var nextId = 1;
+        foreach (var relationship in root.Elements().Where(element => string.Equals(element.Name.LocalName, "Relationship", StringComparison.Ordinal)))
+        {
+            var idAttribute = relationship.Attribute("Id");
+            if (idAttribute is not null)
+            {
+                idAttribute.Value = $"rId{nextId}";
+                nextId++;
+            }
+        }
+    }
+
+    private static void NormalizeElement(XElement element)
+    {
+        var attributes = element.Attributes()
+            .OrderBy(attribute => attribute.Name.NamespaceName, StringComparer.Ordinal)
+            .ThenBy(attribute => attribute.Name.LocalName, StringComparer.Ordinal)
+            .ToArray();
+
+        element.ReplaceAttributes(attributes);
+
+        foreach (var child in element.Elements())
+        {
+            NormalizeElement(child);
+        }
+    }
+
+    private static string Serialize(PptxPackageSnapshot snapshot)
+        => JsonSerializer.Serialize(snapshot, JsonOptions).Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private static bool ShouldUpdateFixtures()
+        => string.Equals(Environment.GetEnvironmentVariable("UPDATE_GOLDEN_PACKAGES"), "1", StringComparison.Ordinal);
+
+    private static string GetFixturePath(string fixtureFileName)
+    {
+        var root = FindRepositoryRoot();
+        return Path.Combine(root, "tests", "MarpToPptx.Tests", "Fixtures", fixtureFileName);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "MarpToPptx.slnx")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the repository root from the test output directory.");
+    }
+
+    private sealed record PptxPackageSnapshot(
+        string[] Entries,
+        IReadOnlyDictionary<string, string> NormalizedXmlParts);
+}

--- a/tests/MarpToPptx.Tests/PptxRendererTests.cs
+++ b/tests/MarpToPptx.Tests/PptxRendererTests.cs
@@ -11,36 +11,101 @@ namespace MarpToPptx.Tests;
 public class PptxRendererTests
 {
     [Fact]
+    public void Renderer_MatchesGoldenPackageBaseline_ForMinimalDeck()
+    {
+        using var workspace = TestWorkspace.Create();
+
+        var markdownPath = workspace.WriteMarkdown(
+            "deck.md",
+            """
+            # Title Slide
+
+            Intro paragraph.
+
+            ---
+
+            ## Second Slide
+
+            - Alpha
+            - Beta
+
+            ![Pixel](pixel.png)
+            """);
+
+        workspace.WriteFile(
+            "pixel.png",
+            Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WnV9a4AAAAASUVORK5CYII="));
+
+        var outputPath = workspace.GetPath("deck.pptx");
+        RenderDeck(markdownPath, outputPath, workspace.RootPath);
+
+        PptxGoldenPackage.AssertMatchesFixture(outputPath, "minimal-deck.package.json");
+    }
+
+    [Fact]
+    public void Renderer_MatchesGoldenPackageBaseline_ForSvgBackgroundDeck()
+    {
+        using var workspace = TestWorkspace.Create();
+
+        workspace.WriteFile(
+            "accent-wave.svg",
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <rect width="100" height="100" fill="#102A43" />
+              <path d="M0 70 C 20 40, 40 40, 60 70 S 100 100, 100 60 L100 100 L0 100 Z" fill="#F7C948" />
+            </svg>
+            """);
+
+        var markdownPath = workspace.WriteMarkdown(
+            "deck.md",
+            """
+            ---
+            theme: gaia
+            backgroundColor: "#F7F3E8"
+            ---
+
+            # Quoted Color
+
+            ---
+
+            <!-- backgroundImage: url(accent-wave.svg) -->
+            # Svg Background
+            """);
+
+        var outputPath = workspace.GetPath("deck.pptx");
+        RenderDeck(markdownPath, outputPath, workspace.RootPath);
+
+        PptxGoldenPackage.AssertMatchesFixture(outputPath, "svg-background.package.json");
+    }
+
+    [Fact]
     public void Renderer_CreatesPresentationWithSlidesTextAndImage()
     {
-        var tempRoot = Path.Combine(Path.GetTempPath(), "MarpToPptx.Tests", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(tempRoot);
+        using var workspace = TestWorkspace.Create();
 
-        var markdownPath = Path.Combine(tempRoot, "deck.md");
-        var imagePath = Path.Combine(tempRoot, "pixel.png");
-        var outputPath = Path.Combine(tempRoot, "deck.pptx");
+        var markdownPath = workspace.WriteMarkdown(
+            "deck.md",
+            """
+            # Title Slide
 
-        File.WriteAllBytes(imagePath, Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WnV9a4AAAAASUVORK5CYII="));
-        File.WriteAllText(markdownPath, """
-        # Title Slide
+            Intro paragraph.
 
-        Intro paragraph.
+            ---
 
-        ---
+            ## Second Slide
 
-        ## Second Slide
+            - Alpha
+            - Beta
 
-        - Alpha
-        - Beta
+            ![Pixel](pixel.png)
+            """);
 
-        ![Pixel](pixel.png)
-        """);
+        workspace.WriteFile(
+            "pixel.png",
+            Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WnV9a4AAAAASUVORK5CYII="));
 
-        var compiler = new MarpCompiler();
-        var deck = compiler.Compile(File.ReadAllText(markdownPath), markdownPath);
-
-        var renderer = new OpenXmlPptxRenderer();
-        renderer.Render(deck, outputPath, new PptxRenderOptions { SourceDirectory = tempRoot });
+        var outputPath = workspace.GetPath("deck.pptx");
+        RenderDeck(markdownPath, outputPath, workspace.RootPath);
 
         using var document = PresentationDocument.Open(outputPath, false);
         var presentationPart = document.PresentationPart;
@@ -84,39 +149,35 @@ public class PptxRendererTests
     [Fact]
     public void Renderer_AcceptsQuotedFrontMatterColorsAndSvgBackgrounds()
     {
-        var tempRoot = Path.Combine(Path.GetTempPath(), "MarpToPptx.Tests", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(tempRoot);
+        using var workspace = TestWorkspace.Create();
 
-        var markdownPath = Path.Combine(tempRoot, "deck.md");
-        var svgPath = Path.Combine(tempRoot, "accent-wave.svg");
-        var outputPath = Path.Combine(tempRoot, "deck.pptx");
+        workspace.WriteFile(
+            "accent-wave.svg",
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <rect width="100" height="100" fill="#102A43" />
+              <path d="M0 70 C 20 40, 40 40, 60 70 S 100 100, 100 60 L100 100 L0 100 Z" fill="#F7C948" />
+            </svg>
+            """);
 
-        File.WriteAllText(svgPath, """
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-          <rect width="100" height="100" fill="#102A43" />
-          <path d="M0 70 C 20 40, 40 40, 60 70 S 100 100, 100 60 L100 100 L0 100 Z" fill="#F7C948" />
-        </svg>
-        """);
+        var markdownPath = workspace.WriteMarkdown(
+            "deck.md",
+            """
+            ---
+            theme: gaia
+            backgroundColor: "#F7F3E8"
+            ---
 
-        File.WriteAllText(markdownPath, """
-        ---
-        theme: gaia
-        backgroundColor: "#F7F3E8"
-        ---
+            # Quoted Color
 
-        # Quoted Color
+            ---
 
-        ---
+            <!-- backgroundImage: url(accent-wave.svg) -->
+            # Svg Background
+            """);
 
-        <!-- backgroundImage: url(accent-wave.svg) -->
-        # Svg Background
-        """);
-
-        var compiler = new MarpCompiler();
-        var deck = compiler.Compile(File.ReadAllText(markdownPath), markdownPath);
-
-        var renderer = new OpenXmlPptxRenderer();
-        renderer.Render(deck, outputPath, new PptxRenderOptions { SourceDirectory = tempRoot });
+        var outputPath = workspace.GetPath("deck.pptx");
+        RenderDeck(markdownPath, outputPath, workspace.RootPath);
 
         using var document = PresentationDocument.Open(outputPath, false);
         var validationErrors = new OpenXmlPackageValidator().Validate(document);
@@ -126,5 +187,59 @@ public class PptxRendererTests
         using var contentTypesReader = new StreamReader(archive.GetEntry("[Content_Types].xml")!.Open());
         var contentTypes = contentTypesReader.ReadToEnd();
         Assert.Contains("image/svg+xml", contentTypes);
+    }
+
+    private static void RenderDeck(string markdownPath, string outputPath, string sourceDirectory)
+    {
+        var compiler = new MarpCompiler();
+        var deck = compiler.Compile(File.ReadAllText(markdownPath), markdownPath);
+
+        var renderer = new OpenXmlPptxRenderer();
+        renderer.Render(deck, outputPath, new PptxRenderOptions { SourceDirectory = sourceDirectory });
+    }
+
+    private sealed class TestWorkspace : IDisposable
+    {
+        private TestWorkspace(string rootPath)
+        {
+            RootPath = rootPath;
+        }
+
+        public string RootPath { get; }
+
+        public static TestWorkspace Create()
+        {
+            var rootPath = Path.Combine(Path.GetTempPath(), "MarpToPptx.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(rootPath);
+            return new TestWorkspace(rootPath);
+        }
+
+        public string GetPath(string relativePath)
+            => Path.Combine(RootPath, relativePath);
+
+        public string WriteMarkdown(string relativePath, string content)
+        {
+            var path = GetPath(relativePath);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        public void WriteFile(string relativePath, string content)
+        {
+            File.WriteAllText(GetPath(relativePath), content);
+        }
+
+        public void WriteFile(string relativePath, byte[] content)
+        {
+            File.WriteAllBytes(GetPath(relativePath), content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a new golden package testing framework for PPTX output, refactors renderer tests to use this framework, and adds new fixture data for baseline compatibility checks. The main goal is to ensure that the PPTX package structure and key XML content remain stable and compatible, with easy regeneration of baselines when intentional changes occur.