### PR TITLE
Add workspace instructions and prompts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,41 @@
+# MarpToPptx Workspace Instructions
+
+## Project focus
+
+- MarpToPptx is a .NET 10 CLI and library that compiles Marp-flavored Markdown into editable PowerPoint `.pptx` files.
+- Treat `DocumentFormat.OpenXml` as the primary implementation surface for PPTX generation.
+- Use ShapeCrawler as a reference source for PPTX-specific patterns when useful, not as an automatic dependency choice.
+
+## Important repo context
+
+- PowerPoint compatibility is the real success criterion. A package can pass `OpenXmlValidator` and still fail to open or trigger repair in PowerPoint.
+- When changing PPTX generation, preserve package structure and relationship invariants documented in `doc/pptx-compatibility-notes.md`.
+- For `DocumentFormat.OpenXml` `3.4.1`, consult `doc/openxml-3.4.1-audit.md` before assuming newer SDK surface removes manual package-shaping work.
+- Prefer minimal, compatibility-focused changes over broad renderer refactors.
+
+## Validation and testing workflow
+
+- For renderer or package changes, follow this order:
+  1. Run targeted tests in `tests/MarpToPptx.Tests`.
+  2. Generate a sample deck with the local CLI project.
+  3. Validate with `src/MarpToPptx.OpenXmlValidator`.
+  4. If compatibility risk remains, run the PowerPoint smoke flow on Windows.
+- Use `dotnet run --project src/MarpToPptx.Cli -- ...` for local renderer debugging. Do not rely on `dnx` unless you explicitly want the published tool path.
+- Use `pwsh ./scripts/Invoke-PptxSmokeTest.ps1 -InputMarkdown ...` for the quickest end-to-end local check.
+- If golden package baselines intentionally change, regenerate them with `UPDATE_GOLDEN_PACKAGES=1` during the test run.
+
+## Useful scripts and references
+
+- Start with `scripts/README.md` for generation, expansion, structure comparison, and PowerPoint-open verification helpers.
+- Use `doc/pptx-compatibility-notes.md` when debugging repaired or non-opening PPTX output.
+- Use `doc/marp-markdown.md` for repo-specific Marp behavior and directive expectations.
+- Use these external references only when needed for authoritative format or API details:
+  - Open XML SDK: https://github.com/dotnet/Open-XML-SDK
+  - Open XML presentation overview: https://learn.microsoft.com/en-us/office/open-xml/presentation/overview
+  - ShapeCrawler source: https://github.com/ShapeCrawler/ShapeCrawler
+
+## Working guidance for agents
+
+- If validation passes but PowerPoint fails, inspect package structure, relationships, and content types before changing slide content logic.
+- Compare generated output against a known-good PowerPoint or reference package when troubleshooting package-shape issues.
+- Keep instructions files small. Put specialized workflows into prompts or skills instead of expanding this file.

--- a/.github/prompts/investigate-pptx-compatibility.prompt.md
+++ b/.github/prompts/investigate-pptx-compatibility.prompt.md
@@ -1,0 +1,53 @@
+---
+description: "Investigate a PPTX that fails validation, opens with repair, or fails to open in PowerPoint"
+name: "Investigate PPTX Compatibility"
+argument-hint: "PPTX path, sample deck, failing test, or issue summary"
+agent: "agent"
+---
+Investigate a PPTX compatibility problem for this repository.
+
+Use this prompt when a generated `.pptx`:
+- fails `OpenXmlValidator`
+- opens with a PowerPoint repair prompt
+- passes validation but still fails to open in PowerPoint
+- differs from a known-good reference package in suspicious ways
+
+Repository rules:
+- PowerPoint compatibility is the real success criterion.
+- Passing `OpenXmlValidator` is necessary but not sufficient.
+- Prefer package-structure and relationship analysis before changing slide content logic.
+- Use `dotnet run --project src/MarpToPptx.Cli -- ...` for local renderer debugging, not `dnx`, unless the published tool path is the thing being tested.
+
+Required references:
+- `doc/pptx-compatibility-notes.md`
+- `scripts/README.md`
+- `doc/openxml-3.4.1-audit.md` when the question involves SDK capabilities or package-shaping assumptions
+
+Expected workflow:
+1. Identify the failing artifact, scenario, or repro path.
+2. Find the relevant renderer, validator, test, sample, or script entry points.
+3. If needed, recommend or run the repo-standard validation flow in this order:
+   - targeted tests in `tests/MarpToPptx.Tests`
+   - local CLI generation
+   - `.NET` Open XML validation through `src/MarpToPptx.OpenXmlValidator`
+   - PowerPoint smoke flow on Windows when compatibility risk remains
+4. Inspect likely package-shape causes before proposing renderer changes:
+   - required parts
+   - slide, layout, master, and theme relationships
+   - `[Content_Types].xml`
+   - relative vs absolute targets
+   - part inventory differences against a known-good package
+5. If useful, compare against a PowerPoint-authored or other known-good reference package.
+6. Summarize the most likely root cause, the evidence, and the smallest safe next change.
+
+Output requirements:
+- Start with the most likely findings, ordered by severity or confidence.
+- Cite the concrete files, scripts, tests, or package parts that matter.
+- Distinguish clearly between:
+  - validator/schema failures
+  - package-shape or relationship failures
+  - unverified hypotheses
+- If you recommend a code change, prefer the smallest compatibility-focused change.
+- If you recommend more investigation, state the exact next command, script, or comparison to run.
+
+Do not give generic Open XML advice when the repo’s own compatibility notes already define the expected package invariants.

--- a/.github/prompts/review-openxml-shapecrawler-approach.prompt.md
+++ b/.github/prompts/review-openxml-shapecrawler-approach.prompt.md
@@ -1,0 +1,46 @@
+---
+description: "Review a proposed implementation against MarpToPptx constraints, using Open XML SDK as primary and ShapeCrawler as a reference when relevant"
+name: "Review OpenXml Or ShapeCrawler Approach"
+argument-hint: "Feature idea, issue, design sketch, file path, or implementation plan"
+agent: "agent"
+---
+Review a proposed implementation approach for this repository before or during coding.
+
+Use this prompt when evaluating:
+- whether a feature should be implemented directly with `DocumentFormat.OpenXml`
+- whether ShapeCrawler is a good reference or helper for a specific PPTX task
+- whether a proposed refactor is too broad for the compatibility risk involved
+- whether newer Open XML SDK surface area actually removes existing manual package-shaping work
+
+Repository rules:
+- `DocumentFormat.OpenXml` is the primary implementation surface.
+- ShapeCrawler is a reference source or selective helper, not a default abstraction layer.
+- Prefer minimal, compatibility-focused changes over broad renderer rewrites.
+- PowerPoint-open behavior matters more than validator-only cleanliness.
+
+Required references:
+- `doc/pptx-compatibility-notes.md`
+- `doc/openxml-3.4.1-audit.md`
+- `doc/prd.md` when the question involves intended product direction or optional ShapeCrawler usage
+- external references only when needed:
+  - https://github.com/dotnet/Open-XML-SDK
+  - https://learn.microsoft.com/en-us/office/open-xml/presentation/overview
+  - https://github.com/ShapeCrawler/ShapeCrawler
+
+Evaluation criteria:
+1. Does the proposal fit the current semantic model and renderer architecture?
+2. Does it preserve known package and relationship invariants?
+3. Is direct Open XML work clearer and safer than adding or leaning on a helper library?
+4. If ShapeCrawler is involved, is it being used for a narrow productivity gain rather than hiding package-critical logic?
+5. Does the proposal assume the SDK can now do something that `doc/openxml-3.4.1-audit.md` says still requires manual handling?
+6. What is the smallest implementation that proves the behavior safely?
+7. What tests, samples, or smoke checks would need to change?
+
+Output requirements:
+- Give a clear recommendation first: `use direct Open XML`, `use ShapeCrawler as reference only`, `use ShapeCrawler selectively`, or `do not proceed with this approach`.
+- Then explain the reasoning in repo-specific terms.
+- Call out concrete risks such as package-shape regressions, hidden abstraction costs, or mismatch with current models.
+- If the idea is sound, propose a minimal implementation slice and the validation steps required.
+- If the idea is weak, suggest the better alternative instead of stopping at criticism.
+
+Do not answer as if this were a generic PowerPoint library comparison. Ground the recommendation in this repo’s current renderer, validation workflow, and compatibility constraints.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ For integrating `MarpToPptx` into a VS Code authoring workflow in a content repo
 - `scripts/`: PowerShell helpers for local generation, smoke tests, package inspection, and PowerPoint troubleshooting
 - `tests/MarpToPptx.Tests`: xUnit v3 tests running on Microsoft Testing Platform
 - `samples/`: Marp-style sample decks for smoke tests, feature coverage, theme parsing, and compatibility-gap repros
+- `.github/copilot-instructions.md`: concise repo-specific Copilot guidance for PPTX compatibility, testing flow, and reference sources
+- `.github/prompts/`: reusable prompts for PPTX compatibility investigation and implementation review workflows
 - `.github/workflows/ci.yml`: Ubuntu build/test/pack plus an Ubuntu CI-safe PPTX smoke-test job
 
 ## Usage


### PR DESCRIPTION
This pull request adds comprehensive repository-specific instructions and reusable prompts for Copilot and agent workflows, focusing on PPTX compatibility, testing, and implementation review in the MarpToPptx project. These changes clarify how contributors should approach PowerPoint compatibility issues, renderer changes, and the use of Open XML SDK versus ShapeCrawler, ensuring that compatibility and package structure remain the top priorities.