### PR TITLE
Add rich presenter notes formatting

### DIFF
--- a/doc/marp-markdown.md
+++ b/doc/marp-markdown.md
@@ -117,9 +117,21 @@ All recognised directive keys support the `_` prefix. The next slide reverts to 
 
 HTML comments that do **not** match the `<!-- key: value -->` pattern are treated as presenter notes. They are stripped from the slide content and stored in `Slide.Notes`, then emitted as PPTX speaker notes.
 
-```markdown
+Presenter notes preserve line breaks and support Markdown-style formatting for bold, italic, strikethrough, inline code, and fenced code blocks in the emitted PPTX notes text. Non-directive note text is still captured from HTML comments, not from normal slide Markdown blocks.
+
+Compatibility note: during manual PowerPoint testing, inline-code and fenced-code note text may not consistently honor the requested monospace font face in the notes pane, even though the PPTX run structure is emitted with code-oriented formatting. Treat note code formatting as best-effort PowerPoint compatibility rather than a strict visual guarantee.
+
+````markdown
 <!-- This is a presenter note, not a directive. -->
+
+<!-- **Bold** and *italic* and `code` inside notes. -->
+
+<!--
+```csharp
+Console.WriteLine("notes code block");
 ```
+-->
+````
 
 ## Current MarpToPptx Compatibility Profile
 

--- a/doc/release-validation.md
+++ b/doc/release-validation.md
@@ -57,6 +57,7 @@ Open each generated deck from `artifacts/manual-review/` in PowerPoint Desktop a
 - code blocks, lists, and tables remain editable and visually coherent
 - local media placeholders and embedded media objects appear as expected on `04-content-coverage.pptx`
 - remote asset slides render correctly on `06-remote-assets.pptx`
+- presenter notes appear on the expected slides in `07-presenter-notes.pptx`, and the control slide has no notes
 
 ### Sample Focus Areas
 
@@ -66,6 +67,7 @@ Open each generated deck from `artifacts/manual-review/` in PowerPoint Desktop a
 - `04-content-coverage.pptx`: images, tables, code, MP3, M4A, video
 - `05-compatibility-gaps.pptx`: current non-goals and known-approximation behavior
 - `06-remote-assets.pptx`: real HTTP(S) image fetches
+- `07-presenter-notes.pptx`: explicit presenter notes packaging and slide-to-notes attachment
 
 ## Current Exclusions
 

--- a/samples/07-presenter-notes.md
+++ b/samples/07-presenter-notes.md
@@ -1,0 +1,49 @@
+# Presenter Notes Smoke
+
+This deck explicitly exercises presenter notes packaging and slide-to-notes attachment.
+
+<!--
+Presenter note for slide 1.
+- checklist item
+- second item with **bold**, *italic*, and `code` markers that should render with formatting
+
+```csharp
+var total = items.Count;
+Console.WriteLine(total);
+```
+-->
+
+---
+
+## No Notes On This Slide
+
+This slide is the control case and should not get a notes part.
+
+---
+
+<!-- header: Presenter Notes Header -->
+## Directives And Notes
+
+This slide mixes a real directive comment with presenter notes.
+
+<!--
+First presenter note paragraph for slide 3.
+Formatting markers like **bold** and _italic_ should render as formatted note text.
+-->
+<!-- Second presenter note line for slide 3. -->
+
+---
+
+## Final Notes Check
+
+The final slide confirms notes still attach correctly later in the deck.
+
+<!--
+Presenter note for slide 4.
+1. Numbered item
+2. Another item
+
+```json
+{ "status": "ok" }
+```
+-->

--- a/samples/README.md
+++ b/samples/README.md
@@ -22,6 +22,9 @@ Intentionally includes Marp features that are not fully implemented yet so behav
 6. `06-remote-assets.md`
 Opt-in integration smoke deck for real HTTP(S) image fetches using commit-pinned raw GitHub URLs.
 
+7. `07-presenter-notes.md`
+Dedicated smoke deck for presenter notes packaging, including note-bearing slides, a no-notes control slide, and a slide that mixes directive comments with presenter notes.
+
 ## Running The Samples
 
 Run any sample with the published tool:
@@ -47,5 +50,6 @@ dotnet run --project src/MarpToPptx.Cli -- samples/03-theme-css.md --theme-css s
 - Asset references are relative to each sample Markdown file.
 - `04-content-coverage.md` depends on the small local media fixtures under `samples/assets/`.
 - `06-remote-assets.md` is intended for integration smoke testing and should be run with remote assets explicitly enabled.
+- `07-presenter-notes.md` is the explicit smoke deck for speaker notes and PowerPoint-open compatibility of emitted notes parts.
 - The compatibility-gap sample is useful for validating current limitations without needing to invent ad hoc repros.
 - Output paths above target `artifacts/samples/`, but any writable location will work.

--- a/src/MarpToPptx.Core/Models/SlideDeck.cs
+++ b/src/MarpToPptx.Core/Models/SlideDeck.cs
@@ -26,6 +26,8 @@ public sealed class Slide
     public SlideStyle Style { get; init; } = new();
 
     public string? Notes { get; init; }
+
+    public IReadOnlyList<InlineSpan> NoteSpans { get; init; } = [];
 }
 
 public sealed class SlideStyle

--- a/src/MarpToPptx.Core/Parsing/MarpMarkdownParser.cs
+++ b/src/MarpToPptx.Core/Parsing/MarpMarkdownParser.cs
@@ -10,6 +10,7 @@ namespace MarpToPptx.Core.Parsing;
 
 public sealed class MarpMarkdownParser
 {
+
     // Matches the opening or self-closing <video> tag and captures the src attribute value.
     private static readonly Regex VideoTagRegex = new(
         @"<video\b[^>]*?\bsrc\s*=\s*(?:""([^""]*)""|'([^']*)'|(\S+?)(?:\s|/?>))",
@@ -89,7 +90,7 @@ public sealed class MarpMarkdownParser
             var (effectiveStyle, newCarryForward, cleaned, notes) = MarpDirectiveParser.Parse(chunk, carryForwardStyle);
             carryForwardStyle = newCarryForward;
 
-            var slide = new Slide { Style = effectiveStyle, Notes = notes };
+            var slide = new Slide { Style = effectiveStyle, Notes = notes, NoteSpans = ParseNoteSpans(notes) };
             foreach (var element in ParseElements(cleaned))
             {
                 slide.Elements.Add(element);
@@ -135,6 +136,110 @@ public sealed class MarpMarkdownParser
         }
 
         return elements;
+    }
+
+    private IReadOnlyList<InlineSpan> ParseNoteSpans(string? notes)
+    {
+        if (string.IsNullOrWhiteSpace(notes))
+        {
+            return [];
+        }
+
+        var document = Markdown.Parse(notes, _pipeline);
+        var spans = new List<InlineSpan>();
+        foreach (var block in document)
+        {
+            var blockSpans = block switch
+            {
+                HeadingBlock heading => TrimSpans(ExtractInlineSpans(heading.Inline)),
+                ParagraphBlock paragraph => TrimSpans(ExtractInlineSpans(paragraph.Inline)),
+                ListBlock list => FlattenNoteListSpans(list),
+                FencedCodeBlock fencedCode => FlattenCodeBlockSpans(fencedCode),
+                CodeBlock codeBlock => FlattenCodeBlockSpans(codeBlock),
+                _ => [],
+            };
+
+            if (blockSpans.Count == 0)
+            {
+                continue;
+            }
+
+            if (spans.Count > 0)
+            {
+                spans.Add(new InlineSpan("\n"));
+            }
+
+            spans.AddRange(blockSpans);
+        }
+
+        return spans.Count > 0 ? spans : CreateLiteralNoteSpans(notes);
+    }
+
+    private static IReadOnlyList<InlineSpan> FlattenNoteListSpans(ListBlock list)
+    {
+        var spans = new List<InlineSpan>();
+        var items = FlattenListItems(list).ToArray();
+        for (var index = 0; index < items.Length; index++)
+        {
+            if (index > 0)
+            {
+                spans.Add(new InlineSpan("\n"));
+            }
+
+            var item = items[index];
+            var indent = item.Depth > 0 ? new string(' ', item.Depth * 2) : string.Empty;
+            var prefix = list.IsOrdered ? $"{indent}{index + 1}. " : $"{indent}• ";
+            spans.Add(new InlineSpan(prefix));
+            spans.AddRange(item.Spans);
+        }
+
+        return spans;
+    }
+
+    private static IReadOnlyList<InlineSpan> FlattenCodeBlockSpans(CodeBlock codeBlock)
+    {
+        var text = codeBlock.Lines.ToString() ?? string.Empty;
+        if (text.Length == 0)
+        {
+            return [];
+        }
+
+        var lines = text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n', StringSplitOptions.None);
+        var spans = new List<InlineSpan>();
+        for (var index = 0; index < lines.Length; index++)
+        {
+            if (index > 0)
+            {
+                spans.Add(new InlineSpan("\n"));
+            }
+
+            if (lines[index].Length > 0)
+            {
+                spans.Add(new InlineSpan(lines[index], Code: true));
+            }
+        }
+
+        return spans;
+    }
+
+    private static IReadOnlyList<InlineSpan> CreateLiteralNoteSpans(string notes)
+    {
+        var spans = new List<InlineSpan>();
+        var lines = notes.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n', StringSplitOptions.None);
+        for (var index = 0; index < lines.Length; index++)
+        {
+            if (index > 0)
+            {
+                spans.Add(new InlineSpan("\n"));
+            }
+
+            if (lines[index].Length > 0)
+            {
+                spans.Add(new InlineSpan(lines[index]));
+            }
+        }
+
+        return spans;
     }
 
     private static void AppendHtmlBlockElements(HtmlBlock htmlBlock, ICollection<ISlideElement> elements)

--- a/src/MarpToPptx.Pptx/Rendering/OpenXmlPptxRenderer.cs
+++ b/src/MarpToPptx.Pptx/Rendering/OpenXmlPptxRenderer.cs
@@ -376,24 +376,32 @@ public sealed class OpenXmlPptxRenderer
 
         if (!string.IsNullOrWhiteSpace(slideModel.Notes))
         {
-            AddNotesSlide(presentationPart, slidePart, slideModel.Notes!, language);
+            AddNotesSlide(presentationPart, slidePart, slideModel.NoteSpans, slideModel.Notes!, effectiveTheme, language);
         }
     }
 
     private static TextStyle ResolveHeadingStyle(ThemeDefinition theme, int level)
         => theme.GetHeadingStyle(level);
 
-    private static void AddNotesSlide(PresentationPart presentationPart, SlidePart slidePart, string notes, string language)
+    private static void AddNotesSlide(PresentationPart presentationPart, SlidePart slidePart, IReadOnlyList<InlineSpan> noteSpans, string notes, ThemeDefinition theme, string language)
     {
         var notesMasterPart = EnsureNotesMasterPart(presentationPart);
         var notesSlidePart = slidePart.AddNewPart<NotesSlidePart>(GetNextRelationshipId(slidePart));
         notesSlidePart.AddPart(notesMasterPart, "rId1");
         notesSlidePart.AddPart(slidePart, GetNextRelationshipId(notesSlidePart));
 
-        var paragraphs = notes
-            .Replace("\r\n", "\n", StringComparison.Ordinal)
-            .Split('\n', StringSplitOptions.None)
-            .Select(line => CreateNotesParagraph(line, language))
+        var effectiveNoteSpans = noteSpans.Count > 0
+            ? noteSpans
+            : CreateLiteralNoteSpans(notes);
+
+        var noteTextStyle = CreateNotesTextStyle(theme);
+        var noteCodeStyle = noteTextStyle with
+        {
+            Color = theme.Code.Color,
+            FontFamily = theme.Code.FontFamily,
+        };
+        var paragraphs = SplitSpansIntoParagraphs(effectiveNoteSpans)
+            .Select(group => CreateParagraphFromSpans(group, noteTextStyle, noteCodeStyle, null, null, false, 1, language))
             .ToArray();
 
         var notesTextBody = new P.TextBody(new A.BodyProperties(), new A.ListStyle());
@@ -490,19 +498,6 @@ public sealed class OpenXmlPptxRenderer
         return notesMasterPart;
     }
 
-    private static A.Paragraph CreateNotesParagraph(string line, string language)
-    {
-        var paragraph = new A.Paragraph();
-        if (!string.IsNullOrEmpty(line))
-        {
-            var runProperties = new A.RunProperties { Language = language };
-            paragraph.Append(new A.Run(runProperties, new A.Text(line)));
-        }
-
-        paragraph.Append(new A.EndParagraphRunProperties { Language = language });
-        return paragraph;
-    }
-
     private static void EnsureNotesMasterThemePart(PresentationPart presentationPart, NotesMasterPart notesMasterPart)
     {
         if (notesMasterPart.ThemePart is not null)
@@ -526,6 +521,37 @@ public sealed class OpenXmlPptxRenderer
             ? CreateTheme()
             : (A.Theme)sourceTheme.CloneNode(true);
     }
+
+    private static IReadOnlyList<InlineSpan> CreateLiteralNoteSpans(string notes)
+    {
+        var spans = new List<InlineSpan>();
+        var lines = notes.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n', StringSplitOptions.None);
+        for (var index = 0; index < lines.Length; index++)
+        {
+            if (index > 0)
+            {
+                spans.Add(new InlineSpan("\n"));
+            }
+
+            if (lines[index].Length > 0)
+            {
+                spans.Add(new InlineSpan(lines[index]));
+            }
+        }
+
+        return spans;
+    }
+
+    private static TextStyle CreateNotesTextStyle(ThemeDefinition theme)
+        => new(
+            FontSize: 12,
+            Color: theme.Body.Color,
+            FontFamily: theme.Body.FontFamily,
+            Bold: false,
+            BackgroundColor: null,
+            LineHeight: theme.Body.LineHeight,
+            LetterSpacing: theme.Body.LetterSpacing,
+            TextTransform: null);
 
     private static void AddBackground(SlideStyle style, SlideRenderContext context)
     {

--- a/tests/MarpToPptx.Tests/ParserTests.cs
+++ b/tests/MarpToPptx.Tests/ParserTests.cs
@@ -388,6 +388,85 @@ public class ParserTests
     }
 
     [Fact]
+    public void Parser_ParsesPresenterNoteFormattingIntoNoteSpans()
+    {
+        const string markdown = """
+        # Slide
+
+        <!--
+        First note line.
+        - bullet item with **bold** and `code`
+        -->
+        <!-- Second note line with _italic_. -->
+        """;
+
+        var compiler = new MarpCompiler();
+        var deck = compiler.Compile(markdown);
+
+        var slide = Assert.Single(deck.Slides);
+        Assert.Equal("First note line.\n- bullet item with **bold** and `code`\nSecond note line with _italic_.", slide.Notes);
+        Assert.Collection(
+            slide.NoteSpans,
+            span => Assert.Equal("First note line.", span.Text),
+            span => Assert.Equal("\n", span.Text),
+            span => Assert.Equal("• ", span.Text),
+            span => Assert.Equal("bullet item with ", span.Text),
+            span =>
+            {
+                Assert.Equal("bold", span.Text);
+                Assert.True(span.Bold);
+            },
+            span => Assert.Equal(" and ", span.Text),
+            span =>
+            {
+                Assert.Equal("code", span.Text);
+                Assert.True(span.Code);
+            },
+            span => Assert.Equal("\n", span.Text),
+            span => Assert.Equal("Second note line with ", span.Text),
+            span =>
+            {
+                Assert.Equal("italic", span.Text);
+                Assert.True(span.Italic);
+            },
+            span => Assert.Equal(".", span.Text));
+    }
+
+    [Fact]
+    public void Parser_ParsesPresenterNoteCodeBlockIntoCodeSpans()
+    {
+        const string markdown = """
+        # Slide
+
+        <!--
+        ```csharp
+        var total = items.Count;
+        Console.WriteLine(total);
+        ```
+        -->
+        """;
+
+        var compiler = new MarpCompiler();
+        var deck = compiler.Compile(markdown);
+
+        var slide = Assert.Single(deck.Slides);
+        Assert.Equal("```csharp\nvar total = items.Count;\nConsole.WriteLine(total);\n```", slide.Notes);
+        Assert.Collection(
+            slide.NoteSpans,
+            span =>
+            {
+                Assert.Equal("var total = items.Count;", span.Text);
+                Assert.True(span.Code);
+            },
+            span => Assert.Equal("\n", span.Text),
+            span =>
+            {
+                Assert.Equal("Console.WriteLine(total);", span.Text);
+                Assert.True(span.Code);
+            });
+    }
+
+    [Fact]
     public void Parser_NoteCommentIsNotEmittedAsSlideElement()
     {
         const string markdown = """

--- a/tests/MarpToPptx.Tests/PptxRendererTests.cs
+++ b/tests/MarpToPptx.Tests/PptxRendererTests.cs
@@ -1210,6 +1210,82 @@ public class PptxRendererTests
     }
 
     [Fact]
+    public void Renderer_FormatsPresenterNotesWithRichRuns()
+    {
+        using var workspace = TestWorkspace.Create();
+
+        var markdownPath = workspace.WriteMarkdown(
+            "deck.md",
+            """
+            # Title Slide
+
+            <!-- **Bold** and *italic* and `code` and ~~strike~~ -->
+            """);
+
+        var outputPath = workspace.GetPath("deck.pptx");
+        RenderDeck(markdownPath, outputPath, workspace.RootPath);
+
+        using var document = PresentationDocument.Open(outputPath, false);
+        var runs = document.PresentationPart!.SlideParts.Single()
+            .NotesSlidePart!.NotesSlide!
+            .Descendants<A.Run>()
+            .ToArray();
+
+        var boldRun = Assert.Single(runs, run => run.Text?.Text == "Bold");
+        Assert.True(boldRun.RunProperties?.Bold?.Value);
+
+        var italicRun = Assert.Single(runs, run => run.Text?.Text == "italic");
+        Assert.True(italicRun.RunProperties?.Italic?.Value);
+
+        var codeRun = Assert.Single(runs, run => run.Text?.Text == "code");
+        Assert.Equal("Cascadia Mono", codeRun.RunProperties?.GetFirstChild<A.LatinFont>()?.Typeface?.Value);
+
+        var strikeRun = Assert.Single(runs, run => run.Text?.Text == "strike");
+        Assert.Equal(A.TextStrikeValues.SingleStrike, strikeRun.RunProperties?.Strike?.Value);
+    }
+
+    [Fact]
+    public void Renderer_FormatsPresenterNoteCodeBlocksWithMonospaceRuns()
+    {
+        using var workspace = TestWorkspace.Create();
+
+        var markdownPath = workspace.WriteMarkdown(
+            "deck.md",
+            """
+            # Title Slide
+
+            <!--
+            ```csharp
+            var total = items.Count;
+            Console.WriteLine(total);
+            ```
+            -->
+            """);
+
+        var outputPath = workspace.GetPath("deck.pptx");
+        RenderDeck(markdownPath, outputPath, workspace.RootPath);
+
+        using var document = PresentationDocument.Open(outputPath, false);
+        var runs = document.PresentationPart!.SlideParts.Single()
+            .NotesSlidePart!.NotesSlide!
+            .Descendants<A.Run>()
+            .ToArray();
+
+        Assert.Collection(
+            runs,
+            run =>
+            {
+                Assert.Equal("var total = items.Count;", run.Text?.Text);
+                Assert.Equal("Cascadia Mono", run.RunProperties?.GetFirstChild<A.LatinFont>()?.Typeface?.Value);
+            },
+            run =>
+            {
+                Assert.Equal("Console.WriteLine(total);", run.Text?.Text);
+                Assert.Equal("Cascadia Mono", run.RunProperties?.GetFirstChild<A.LatinFont>()?.Typeface?.Value);
+            });
+    }
+
+    [Fact]
     public void Renderer_CreatesNotesForMultipleSlides_AttachedToCorrectSlides()
     {
         using var workspace = TestWorkspace.Create();


### PR DESCRIPTION
## Summary
- parse presenter notes into inline spans instead of preserving formatting markers as plain text
- render formatted note runs including emphasis, strikethrough, inline code, and fenced code blocks
- add parser and renderer coverage plus a dedicated presenter-notes smoke sample and docs updates

## Validation
- ran focused parser and renderer tests covering note formatting and note code blocks
- validated the presenter-notes smoke sample

Stacked on #70.