### PR TITLE
Fix presenter notes PowerPoint compatibility

### DIFF
--- a/src/MarpToPptx.Pptx/Rendering/OpenXmlPptxRenderer.cs
+++ b/src/MarpToPptx.Pptx/Rendering/OpenXmlPptxRenderer.cs
@@ -388,6 +388,7 @@ public sealed class OpenXmlPptxRenderer
         var notesMasterPart = EnsureNotesMasterPart(presentationPart);
         var notesSlidePart = slidePart.AddNewPart<NotesSlidePart>(GetNextRelationshipId(slidePart));
         notesSlidePart.AddPart(notesMasterPart, "rId1");
+        notesSlidePart.AddPart(slidePart, GetNextRelationshipId(notesSlidePart));
 
         var paragraphs = notes
             .Replace("\r\n", "\n", StringComparison.Ordinal)
@@ -432,6 +433,7 @@ public sealed class OpenXmlPptxRenderer
         if (presentationPart.NotesMasterPart is not null)
         {
             var existingNotesMasterPart = presentationPart.NotesMasterPart;
+            EnsureNotesMasterThemePart(presentationPart, existingNotesMasterPart);
             var existingRelId = presentationPart.GetIdOfPart(existingNotesMasterPart);
 
             var notesMasterIdList = presentationPart.Presentation!.NotesMasterIdList ??= new P.NotesMasterIdList();
@@ -478,6 +480,7 @@ public sealed class OpenXmlPptxRenderer
                 Hyperlink = A.ColorSchemeIndexValues.Hyperlink,
                 FollowedHyperlink = A.ColorSchemeIndexValues.FollowedHyperlink,
             });
+        EnsureNotesMasterThemePart(presentationPart, notesMasterPart);
         notesMasterPart.NotesMaster.Save();
 
         var relId = presentationPart.GetIdOfPart(notesMasterPart);
@@ -498,6 +501,30 @@ public sealed class OpenXmlPptxRenderer
 
         paragraph.Append(new A.EndParagraphRunProperties { Language = language });
         return paragraph;
+    }
+
+    private static void EnsureNotesMasterThemePart(PresentationPart presentationPart, NotesMasterPart notesMasterPart)
+    {
+        if (notesMasterPart.ThemePart is not null)
+        {
+            notesMasterPart.ThemePart.Theme ??= ClonePresentationTheme(presentationPart);
+            notesMasterPart.ThemePart.Theme.Save();
+            return;
+        }
+
+        var themePart = notesMasterPart.AddNewPart<ThemePart>(GetNextRelationshipId(notesMasterPart));
+        themePart.Theme = ClonePresentationTheme(presentationPart);
+        themePart.Theme.Save();
+    }
+
+    private static A.Theme ClonePresentationTheme(PresentationPart presentationPart)
+    {
+        var sourceTheme = presentationPart.SlideMasterParts.FirstOrDefault()?.ThemePart?.Theme
+            ?? presentationPart.ThemePart?.Theme;
+
+        return sourceTheme is null
+            ? CreateTheme()
+            : (A.Theme)sourceTheme.CloneNode(true);
     }
 
     private static void AddBackground(SlideStyle style, SlideRenderContext context)

--- a/tests/MarpToPptx.Tests/PptxRendererTests.cs
+++ b/tests/MarpToPptx.Tests/PptxRendererTests.cs
@@ -1263,6 +1263,57 @@ public class PptxRendererTests
     }
 
     [Fact]
+    public void Renderer_EmitsNotesRelationshipsNeededForPowerPointCompatibility()
+    {
+        using var workspace = TestWorkspace.Create();
+
+        var markdownPath = workspace.WriteMarkdown(
+            "deck.md",
+            """
+            # Title Slide
+
+            Body text.
+
+            <!-- Presenter note text. -->
+            """);
+
+        var outputPath = workspace.GetPath("deck.pptx");
+        RenderDeck(markdownPath, outputPath, workspace.RootPath);
+
+        using var document = PresentationDocument.Open(outputPath, false);
+        var slidePart = document.PresentationPart!.SlideParts.Single();
+        var notesSlidePart = slidePart.NotesSlidePart;
+        var notesMasterPart = document.PresentationPart.NotesMasterPart;
+
+        Assert.NotNull(notesSlidePart);
+        Assert.NotNull(notesMasterPart);
+        Assert.NotNull(notesMasterPart!.ThemePart);
+        Assert.Equal("/ppt/slides/slide1.xml", notesSlidePart!.SlidePart?.Uri.ToString());
+        Assert.Equal(notesMasterPart.Uri, notesSlidePart.NotesMasterPart?.Uri);
+
+        using var archive = ZipFile.OpenRead(outputPath);
+
+        var notesMasterRelationshipsEntry = archive.GetEntry("ppt/notesMasters/_rels/notesMaster1.xml.rels");
+        Assert.NotNull(notesMasterRelationshipsEntry);
+        using (var reader = new StreamReader(notesMasterRelationshipsEntry!.Open()))
+        {
+            var xml = reader.ReadToEnd();
+            Assert.Contains("relationships/theme", xml);
+            Assert.Contains("theme", xml);
+        }
+
+        var notesSlideRelationshipsEntry = archive.GetEntry("ppt/notesSlides/_rels/notesSlide1.xml.rels");
+        Assert.NotNull(notesSlideRelationshipsEntry);
+        using (var reader = new StreamReader(notesSlideRelationshipsEntry!.Open()))
+        {
+            var xml = reader.ReadToEnd();
+            Assert.Contains("relationships/notesMaster", xml);
+            Assert.Contains("relationships/slide", xml);
+            Assert.Contains("../slides/slide1.xml", xml);
+        }
+    }
+
+    [Fact]
     public void Renderer_DoesNotCreateNotesSlidePart_WhenSlideHasNoNotes()
     {
         using var workspace = TestWorkspace.Create();


### PR DESCRIPTION
## Summary
- add the missing slide relationship from notes slides back to their owning slides
- ensure notes masters include theme wiring PowerPoint expects
- add a regression test for the emitted notes relationship graph

## Validation
- ran the targeted notes compatibility regression test

Closes #66