### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/jongalloway/MarpToPptx/security/code-scanning/2](https://github.com/jongalloway/MarpToPptx/security/code-scanning/2)

To fix the problem, explicitly define a `permissions` block that grants only the minimal required access to the `GITHUB_TOKEN`. In this workflow, all steps only need to read repository contents and do not need to write to the repo or interact with issues/PRs, so `contents: read` is sufficient. Adding this at the root of the workflow applies it to all jobs unless overridden, which matches the current behavior while constraining token privileges.

The best minimal change is to add a root-level `permissions` section immediately after the `name: CI` line (before `on:`). This will ensure both `build-test-pack` and `smoke-test` run with `GITHUB_TOKEN` limited to read-only repository contents. No additional imports, actions, or changes to the jobs/steps are needed, and existing functionality (checkout, restore, build, test, artifact upload) will continue to work.

Specifically, edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: CI`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
