### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -12,6 +12,9 @@ on:
                     - Release
                     - Debug
 
+permissions:
+    contents: read
+
 jobs:
     hosted-release-gate:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jongalloway/MarpToPptx/security/code-scanning/3](https://github.com/jongalloway/MarpToPptx/security/code-scanning/3)

To fix the problem, explicitly set a minimal `permissions` block so that the `GITHUB_TOKEN` has only the access required. This workflow only needs to read the repository contents (for `actions/checkout`) and upload build/test outputs as artifacts. Uploading artifacts does not require repository write permissions; `actions/upload-artifact` uses the workflow’s internal token, and `contents: read` is sufficient for checkout. No step writes to issues, PRs, packages, or other resources.

The best fix is to add a `permissions` section at the workflow root so it applies to all jobs that don’t override it. In `.github/workflows/release-gate.yml`, insert:

```yaml
permissions:
    contents: read
```

after the `on:` block (for example between lines 14 and 15). This leaves functionality unchanged: the workflow will still be dispatchable, will still check out code, build, test, generate samples, and upload artifacts, but the `GITHUB_TOKEN` can no longer be misused for write operations against repository contents or other scopes.

No additional methods, imports, or definitions are needed; this is a pure YAML configuration change within the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
