### PR TITLE
Rewrite README, add CONTRIBUTING, update showcase deck

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to MarpToPptx
+
+## Repository Structure
+
+- `src/MarpToPptx.Core` — semantic slide model, Markdown parsing, theme parsing, layout planning
+- `src/MarpToPptx.Pptx` — Open XML PPTX rendering and template-aware presentation generation
+- `src/MarpToPptx.Cli` — `marp2pptx` command-line entrypoint
+- `src/MarpToPptx.OpenXmlValidator` — .NET validation helper used by smoke tests and CI
+- `scripts/` — PowerShell helpers for local generation, smoke tests, package inspection, and PowerPoint troubleshooting
+- `tests/MarpToPptx.Tests` — xUnit v3 tests running on Microsoft Testing Platform
+- `samples/` — Marp-style sample decks for smoke tests, feature coverage, theme parsing, and compatibility-gap repros
+- `.github/copilot-instructions.md` — repo-specific Copilot guidance for PPTX compatibility, testing flow, and reference sources
+- `.github/prompts/` — reusable prompts for PPTX compatibility investigation and implementation review
+- `.github/workflows/ci.yml` — Ubuntu build/test/pack plus an Ubuntu CI-safe PPTX smoke-test job
+
+## Conventions
+
+- Solution format: `MarpToPptx.slnx`
+- Centralized package management: `Directory.Packages.props`
+- Test framework: xUnit v3
+- Test runner: Microsoft Testing Platform via `global.json`
+- CLI packaging: `marp2pptx` as a .NET tool, with single-file publish as an alternate deployment mode
+
+## Running From Source
+
+```bash
+dotnet run --project src/MarpToPptx.Cli -- input.md -o output.pptx
+dotnet run --project src/MarpToPptx.Cli -- input.md --template theme.pptx
+dotnet run --project src/MarpToPptx.Cli -- input.md --theme-css theme.css
+```
+
+## Local Packaging
+
+Build a local tool package:
+
+```bash
+dotnet pack src/MarpToPptx.Cli -c Release
+```
+
+This produces a tool package under `artifacts/nupkg/` with package ID `MarpToPptx` and command name `marp2pptx`.
+
+Run it with `dnx` from the local package source:
+
+```bash
+dnx MarpToPptx --add-source ./artifacts/nupkg sample.md -o sample.pptx
+```
+
+Or install it as a local tool:
+
+```bash
+dotnet new tool-manifest
+dotnet tool install MarpToPptx --add-source ./artifacts/nupkg
+dotnet tool run marp2pptx sample.md -o sample.pptx
+```
+
+## Releases
+
+NuGet publishing is handled by `.github/workflows/publish.yml` using nuget.org Trusted Publishing with GitHub OIDC.
+
+Pre-release validation is available through `.github/workflows/release-gate.yml`.
+
+- Versioning is tag-based via `MinVer`.
+- Stable release tags use the form `v1.2.3`.
+- The publish workflow builds, tests, packs, and pushes the tool package from `artifacts/nupkg/`.
+
+To cut a release:
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+After the workflow finishes and NuGet indexing completes, install or run the published tool with:
+
+```bash
+dotnet tool install --global MarpToPptx
+dnx MarpToPptx sample.md -o sample.pptx
+```
+
+## Reference Documentation
+
+- [Marp Markdown behavior and directives](doc/marp-markdown.md)
+- [PPTX compatibility notes](doc/pptx-compatibility-notes.md)
+- [`DocumentFormat.OpenXml` 3.4.1 audit](doc/openxml-3.4.1-audit.md)
+- [VS Code workflow integration](doc/vscode-workflow.md)
+- [Release validation and checklist](doc/release-validation.md)
+- [Script helpers](scripts/README.md)

--- a/README.md
+++ b/README.md
@@ -5,63 +5,78 @@
 [![NuGet Downloads](https://img.shields.io/nuget/dt/MarpToPptx?logo=nuget)](https://www.nuget.org/packages/MarpToPptx/)
 [![.NET 10](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet)](https://dotnet.microsoft.com/)
 
-MarpToPptx is a .NET 10 CLI and library for compiling Marp-flavored Markdown into editable PowerPoint presentations.
+**✨ Turn your Marp Markdown into real, editable PowerPoint files.**
 
-For a precise description of how this repo defines and implements Marp-style Markdown, see `doc/marp-markdown.md`.
+So you'd like to write your presentation slides in Markdown? It's lightweight, easy to version, and works great with AI-powered workflows. The amazing [Marp](https://marp.app/) ecosystem has you covered with a mature, open-source solution for authoring beautiful slide decks in plain text:
 
-For renderer and PowerPoint package requirements and compatibility reference material, see `doc/pptx-compatibility-notes.md`.
+- [**Marp**](https://marp.app/) — the Markdown Presentation Ecosystem
+- [**Marp for VS Code**](https://marketplace.visualstudio.com/items?itemName=marp-team.marp-vscode) — live preview and export right in your editor
+- [**Marp CLI**](https://github.com/marp-team/marp-cli) — command-line conversion to HTML, PDF, and PPTX
+- [**awesome-marp**](https://github.com/marp-team/awesome-marp) — community themes, tools, and examples
 
-For the `DocumentFormat.OpenXml` `3.4.1` presentation-impact audit and related follow-up notes, see `doc/openxml-3.4.1-audit.md`.
+There's just one hangup. When you're asked to turn in a PowerPoint deck at a conference, need to share editable slides with a colleague, or want to integrate into an existing corporate deck — you need your slides in real PowerPoint format. Unfortunately, Marp's PPTX export produces uneditable image-per-slide output that you can't select, edit, or restyle.
 
-For integrating `MarpToPptx` into a VS Code authoring workflow in a content repository, see `doc/vscode-workflow.md`.
+**That's where MarpToPptx comes in. 🎉** It reads your Marp-flavored Markdown and produces native Open XML PowerPoint files where every heading, bullet, table, and code block is a real, selectable, editable PowerPoint shape. The output opens cleanly in PowerPoint — no repair prompts, no surprises.
 
-For pre-release validation, hosted LibreOffice gate coverage, and the manual PowerPoint review checklist, see `doc/release-validation.md`.
-
-## Current Structure
-
-- `src/MarpToPptx.Core`: semantic slide model, Markdown parsing, theme parsing, layout planning
-- `src/MarpToPptx.Pptx`: Open XML PPTX rendering and template-aware presentation generation
-- `src/MarpToPptx.Cli`: `marp2pptx` command-line entrypoint
-- `src/MarpToPptx.OpenXmlValidator`: small .NET validation helper used by smoke tests and CI
-- `scripts/`: PowerShell helpers for local generation, smoke tests, package inspection, and PowerPoint troubleshooting
-- `tests/MarpToPptx.Tests`: xUnit v3 tests running on Microsoft Testing Platform
-- `samples/`: Marp-style sample decks for smoke tests, feature coverage, theme parsing, and compatibility-gap repros
-- `.github/copilot-instructions.md`: concise repo-specific Copilot guidance for PPTX compatibility, testing flow, and reference sources
-- `.github/prompts/`: reusable prompts for PPTX compatibility investigation and implementation review workflows
-- `.github/workflows/ci.yml`: Ubuntu build/test/pack plus an Ubuntu CI-safe PPTX smoke-test job
-
-## Usage
-
-### Preferred: DNX
-
-`dnx` is the quickest way to run MarpToPptx without installing it as a persistent tool, but it requires .NET 10.
-
-```bash
-dnx MarpToPptx sample.md -o sample.pptx
-dnx MarpToPptx sample.md --template theme.pptx
-dnx MarpToPptx sample.md --theme-css theme.css
+```mermaid
+flowchart LR
+    A["📝 Marp Markdown"] --> B["⚙️ MarpToPptx"]
+    C["🎨 CSS Theme"] -.-> B
+    D["📊 .pptx Template"] -.-> B
+    B --> E["✅ Editable .pptx"]
+    style A fill:#4a9eff,color:#fff
+    style B fill:#7c3aed,color:#fff
+    style C fill:#f59e0b,color:#fff
+    style D fill:#f59e0b,color:#fff
+    style E fill:#10b981,color:#fff
 ```
 
-### Install As A .NET Tool
+## 🚀 Quick Start
 
-If you prefer a persistent command, install the tool from NuGet:
+MarpToPptx requires [.NET 10](https://dotnet.microsoft.com/download). The fastest way to try it — no install needed:
+
+```bash
+dnx MarpToPptx slides.md -o slides.pptx
+```
+
+Or install it globally as a .NET tool:
 
 ```bash
 dotnet tool install --global MarpToPptx
-marp2pptx sample.md -o sample.pptx
-marp2pptx sample.md --template theme.pptx
-marp2pptx sample.md --theme-css theme.css
+marp2pptx slides.md -o slides.pptx
 ```
 
-To update later:
+### Apply a Theme or Template
+
+Use a CSS theme file for Marp-style theming:
 
 ```bash
-dotnet tool update --global MarpToPptx
+marp2pptx slides.md --theme-css brand.css -o slides.pptx
 ```
 
-### VS Code Task
+Or reuse an existing PowerPoint template to inherit your organization's masters and layouts:
 
-Add a `.vscode/tasks.json` to your content repository to export the currently open file:
+```bash
+marp2pptx slides.md --template corporate.pptx -o slides.pptx
+```
+
+## 📋 Features
+
+| Category | What's supported |
+|---|---|
+| **Slide structure** | Front matter directives, `---` slide splitting, presenter notes |
+| **Text content** | Headings, paragraphs, ordered and unordered lists, bold/italic/code spans |
+| **Rich content** | Local images, syntax-highlighted code blocks, native tables |
+| **Media** | Embedded MP3/M4A audio, embedded video |
+| **Theming** | CSS-based Marp themes (fonts, colors, padding, backgrounds, typography) |
+| **Templates** | Copy masters and layouts from an existing `.pptx` |
+| **Directives** | `backgroundColor`, `backgroundImage`, `header`, `footer`, `paginate`, scoped overrides |
+| **Output quality** | Open XML validated, tested to open without repair prompts in PowerPoint |
+| **Platform** | Runs anywhere .NET 10 runs — CI-tested on Ubuntu, works on Windows and macOS |
+
+## 💻 VS Code Integration
+
+Add a one-click export task to any content repository with a `.vscode/tasks.json`:
 
 ```json
 {
@@ -85,97 +100,38 @@ Add a `.vscode/tasks.json` to your content repository to export the currently op
 }
 ```
 
-Run it from **Terminal → Run Task** while the Markdown file is open. The `.pptx` is written next to the source file.
+Run **Terminal → Run Task → Export to PPTX** while editing a Markdown file. The `.pptx` appears next to your source file.
 
-For template-based export, theme CSS, version pinning, team sharing, and the full edit / preview / export loop with the Marp for VS Code extension, see [`doc/vscode-workflow.md`](doc/vscode-workflow.md).
+For template-based export, version pinning, team sharing, and integrating the Marp for VS Code preview extension, see [`doc/vscode-workflow.md`](doc/vscode-workflow.md).
 
-### Run From Source
+## 🎯 Sample Decks
 
-If you are developing on the repo, you can still run the CLI project directly:
-
-```bash
-dotnet run --project src/MarpToPptx.Cli -- input.md -o output.pptx
-dotnet run --project src/MarpToPptx.Cli -- input.md --template theme.pptx
-dotnet run --project src/MarpToPptx.Cli -- input.md --theme-css theme.css
-```
-
-## Local Packaging
-
-Build a local tool package:
+The [`samples/`](samples/) directory contains ready-to-run Marp decks that exercise different features:
 
 ```bash
-dotnet pack src/MarpToPptx.Cli -c Release
+dnx MarpToPptx samples/01-minimal.md -o artifacts/samples/01-minimal.pptx
+dnx MarpToPptx samples/04-content-coverage.md -o artifacts/samples/04-content-coverage.pptx
+dnx MarpToPptx samples/03-theme-css.md --theme-css samples/03-theme.css -o artifacts/samples/03-theme-css.pptx
 ```
 
-That produces a tool package under `artifacts/nupkg/` with package ID `MarpToPptx` and command name `marp2pptx`.
+See [`samples/README.md`](samples/README.md) for the full list and suggested progression.
 
-Run it with `dnx` from the local package source:
+## 🗺️ Roadmap
 
-```bash
-dnx MarpToPptx --add-source ./artifacts/nupkg sample.md -o sample.pptx
-```
+- Broader CSS coverage for advanced Marp theme features
+- Smarter layout heuristics for dense or highly designed slides
+- Multi-layout template mapping
+- Improved table styling fidelity
+- Expanded syntax highlighting themes
+- Remote asset support
 
-You can also install it as a local tool from the package output:
+## 🤝 Contributing
 
-```bash
-dotnet new tool-manifest
-dotnet tool install MarpToPptx --add-source ./artifacts/nupkg
-dotnet tool run marp2pptx sample.md -o sample.pptx
-```
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for repository structure, conventions, building from source, packaging, and release process.
 
-## Releases
+## 📖 Documentation
 
-NuGet publishing is handled by `.github/workflows/publish.yml` using nuget.org Trusted Publishing with GitHub OIDC.
-
-Heavier pre-release validation is available separately through `.github/workflows/release-gate.yml`.
-
-- Versioning is tag-based via `MinVer`.
-- Stable release tags should use the form `v1.2.3`.
-- The publish workflow builds, tests, packs, and then pushes the tool package from `artifacts/nupkg/`.
-
-To cut a release:
-
-```bash
-git tag v1.2.3
-git push origin v1.2.3
-```
-
-After the workflow finishes and NuGet indexing completes, install or run the published tool with:
-
-```bash
-dotnet tool install --global MarpToPptx
-dnx MarpToPptx sample.md -o sample.pptx
-```
-
-## Repository Conventions
-
-- Solution format: `MarpToPptx.slnx`
-- Centralized package management: `Directory.Packages.props`
-- Test framework: xUnit v3
-- Test runner: Microsoft Testing Platform via `global.json`
-- CLI packaging direction: `marp2pptx` as a .NET tool, while preserving single-file publish as a deployment mode
-
-## Current Milestone
-
-- Marp-style front matter and directive parsing
-- Slide splitting on `---`
-- Semantic slide model independent from PPTX
-- Theme extraction for fonts, colors, padding, background images, and core typography settings
-- PPTX generation for headings, paragraphs, bullet lists, images, code blocks, native tables, and header/footer text
-- Local audio and video embedding for supported media formats
-- Template-copy workflow for reusing an existing `.pptx` theme/master
-
-## Steering Decisions
-
-- `ImageSharp` is intentionally not used for image sizing unless it is explicitly re-approved after licensing review
-- Intrinsic image sizing should prefer built-in platform capabilities or a minimal in-project metadata reader
-- Remaining roadmap work should be evaluated against the current implemented baseline rather than an empty starting point
-
-## Roadmap
-
-- Improve CSS coverage for more Marp theme features
-- Refine layout heuristics for denser or highly designed decks
-- Expand template integration to map multiple layouts intelligently
-- Improve native PPTX table styling and layout fidelity
-- Expand code block highlighting coverage and theme fidelity
-- Support remote assets and additional image formats
+- [Marp Markdown behavior and directives](doc/marp-markdown.md)
+- [PPTX compatibility notes](doc/pptx-compatibility-notes.md)
+- [VS Code workflow integration](doc/vscode-workflow.md)
+- [Release validation checklist](doc/release-validation.md)

--- a/samples/08-showcase.css
+++ b/samples/08-showcase.css
@@ -99,6 +99,7 @@ section.lead {
 }
 
 section.lead h1,
+section.lead h2,
 section.lead strong {
   color: #FFFFFF;
 }

--- a/samples/08-showcase.md
+++ b/samples/08-showcase.md
@@ -2,100 +2,148 @@
 theme: marp-showcase
 paginate: true
 lang: en-US
-header: Marp Ecosystem Showcase
-footer: MarpToPptx smoke sample
+header: MarpToPptx
+footer: github.com/jongalloway/MarpToPptx
 ---
 
 <!-- class: lead -->
 <!-- _backgroundImage: url(assets/marp.svg) -->
 <!-- _backgroundSize: contain -->
-# MarpToPptx Showcase
+# MarpToPptx
 
-Markdown authoring with editable PowerPoint output.
+✨ Turn your Marp Markdown into real, editable PowerPoint files.
 
-This sample is written like a short conference talk about the Marp ecosystem and where MarpToPptx fits.
+<!-- Speaker note: this is the title slide. Set the stage: you love writing slides in Markdown, but sometimes you need a real .pptx. -->
 
-<!-- Speaker framing: introduce the ecosystem first, then position MarpToPptx as the editable-PPTX path for teams that still want Marp-style authoring. -->
+---
+
+<!-- class: -->
+## Writing Slides in Markdown
+
+- It's **lightweight** — plain text, easy to diff and review
+- It's **versionable** — works naturally with Git
+- It's **AI-friendly** — great with Copilot and LLM-powered workflows
+- It's **fast** — focus on content, not clicking through menus
+
+So how do you actually do it?
+
+<!-- Speaker note: frame the value of Markdown-first authoring before introducing Marp. This resonates with developers and technical writers alike. -->
 
 ---
 
 <!-- class: ecosystem -->
-## What Marp Is
+## The Marp Ecosystem
 
-- **Marp** stands for **Markdown Presentation Ecosystem**.
-- It is built around a CommonMark-based authoring model with simple horizontal-rule slide breaks.
-- Marp adds directives, image shortcuts, built-in themes, and CSS theming.
-- The official toolset can export decks to HTML, PDF, and PowerPoint.
+- **Marp** — the Markdown Presentation Ecosystem (marp.app)
+- **Marp for VS Code** — live preview and export right in your editor
+- **Marp CLI** — command-line conversion to HTML, PDF, and PPTX
+- **awesome-marp** — community themes, tools, and examples
 
-The value proposition from the official Marp site is simple: create beautiful slide decks while staying focused on the story in Markdown.
+Marp is mature, open-source, and built on CommonMark with simple `---` slide breaks, front matter directives, and CSS theming.
 
-<!-- Speaker note: this is the framing slide for people who have heard the name but do not know the product boundaries yet. -->
-
----
-
-## The Marp Ecosystem In One Story
-
-- **Marpit** supplies the slide framework and plugin surface.
-- **Marp Core** adds practical authoring features and built-in themes.
-- **Marp for VS Code** makes the write-preview loop fast.
-- **Marp CLI** handles export, watch mode, and automation.
-- **MarpToPptx** adds editable PowerPoint handoff.
-
-The pitch to a speaker is simple: keep writing in Markdown, but hand off a deck that PowerPoint users can still edit slide by slide.
-
-<!-- Speaker note: emphasize coexistence rather than competition. The audience should hear that MarpToPptx is additive to existing Marp workflows. -->
-
----
-
-## Why The Ecosystem Works
-
-- The ecosystem is fully open-source and MIT licensed.
-- The tooling stays close to plain Markdown instead of inventing a separate slide language.
-- Theme CSS remains the main customization surface for design systems.
-- The official tools cover editing, preview, export, and automation.
-- The stack is composable enough for custom workflows and integrations.
+<!-- Speaker note: the audience should understand Marp is a real ecosystem, not a toy. Mention the VS Code extension for the live preview loop. -->
 
 ---
 
 <!-- class: contrast -->
-## What MarpToPptx Adds
+## The Problem
 
-- Keeps Markdown as the authoring source while producing editable PowerPoint shapes.
-- Maps theme, background, header, footer, and pagination intent into PPTX constructs.
-- Uses Open XML validation plus PowerPoint open checks as compatibility gates.
-- Fits teams that want Markdown discipline without giving up ordinary Office collaboration.
+When you need to **hand off a PowerPoint deck**:
 
-This is why the repo treats PowerPoint compatibility as the real success metric, not just schema-valid XML.
+- Conference submission requires `.pptx`
+- Colleague wants to edit a few slides
+- Corporate template needs to be applied
+- Marketing needs to tweak the wording
 
----
+Marp's built-in PPTX export produces **uneditable image-per-slide output** — you can't select, edit, or restyle anything.
 
-## Current Repo Structure
-
-- **MarpToPptx.Core**: parsing, theme extraction, slide model, and layout planning.
-- **MarpToPptx.Pptx**: Open XML rendering and presentation generation.
-- **MarpToPptx.Cli**: the marp2pptx command entrypoint.
-- **MarpToPptx.OpenXmlValidator**: package validation used by smoke tests and CI.
-- **MarpToPptx.Tests**: xUnit v3 coverage on Microsoft Testing Platform.
+<!-- Speaker note: this is the pain point. Let it land. Everyone in the audience has been asked to "just send the PowerPoint." -->
 
 ---
 
-## Capabilities Worth Showing Live
+<!-- class: lead -->
+## That's Where MarpToPptx Comes In 🎉
 
-1. Front matter and slide directives for themes, pagination, classes, backgrounds, headers, and footers.
-2. Built-in Marp ideas such as theme CSS, directive-driven layout changes, and Markdown-first authoring.
-3. Editable PPTX generation for headings, paragraphs, bullet lists, images, code blocks, native tables, and header/footer text.
-4. Local audio and video embedding for supported media formats.
-5. Template-copy workflow for reusing an existing `.pptx` theme or master.
-6. Local and CI-friendly smoke scripts for generation, validation, and PowerPoint-open checks.
+**Native Open XML PowerPoint files** where every heading, bullet, table, and code block is a real, selectable, editable shape.
 
-<!-- Speaker note: this slide is the “why should a team care?” moment. Tie these bullets back to handoff, review, and release workflows. -->
+No repair prompts. No surprises.
+
+<!-- Speaker note: the key message. Pause here and let the contrast with image-per-slide sink in. -->
+
+---
+
+<!-- class: -->
+## How It Works
+
+1. **Parse** — reads Marp-flavored Markdown, front matter, and directives
+2. **Theme** — applies CSS theme or `.pptx` template masters and layouts
+3. **Render** — generates native Open XML shapes for every content element
+4. **Validate** — checks against the Open XML spec before output
+
+The result opens cleanly in PowerPoint on any platform.
+
+<!-- Speaker note: keep this high-level. The audience cares that it works, not the implementation details. -->
+
+---
+
+## Quick Start
+
+No install needed — just .NET 10:
+
+```bash
+dnx MarpToPptx slides.md -o slides.pptx
+```
+
+Or install globally as a .NET tool:
+
+```bash
+dotnet tool install --global MarpToPptx
+marp2pptx slides.md -o slides.pptx
+```
+
+<!-- Speaker note: live demo moment. Show the command, open the resulting .pptx, click on a heading to prove it's editable. -->
+
+---
+
+## Themes and Templates
+
+Apply a CSS theme for Marp-style theming:
+
+```bash
+marp2pptx slides.md --theme-css brand.css -o slides.pptx
+```
+
+Or reuse an existing PowerPoint template:
+
+```bash
+marp2pptx slides.md --template corporate.pptx -o slides.pptx
+```
+
+Your organization's masters, layouts, fonts, and colors carry through.
 
 ---
 
 <!-- class: compact -->
-## VS Code Export Task
+## What's Supported
 
-The repo README shows this inside `tasks.json`:
+| Category | Details |
+|---|---|
+| **Slide structure** | Front matter, `---` splitting, presenter notes |
+| **Text** | Headings, paragraphs, lists, bold/italic/code spans |
+| **Rich content** | Images, syntax-highlighted code blocks, native tables |
+| **Media** | Embedded audio (MP3/M4A) and video |
+| **Theming** | CSS themes — fonts, colors, padding, backgrounds |
+| **Templates** | Copy masters and layouts from existing `.pptx` |
+| **Directives** | Background, header, footer, paginate, scoped overrides |
+
+<!-- Speaker note: scan through quickly. The point is breadth — this isn't a proof of concept. -->
+
+---
+
+<!-- class: -->
+## VS Code Integration
+
+Add a one-click export task to any content repository:
 
 ```json
 {
@@ -106,43 +154,36 @@ The repo README shows this inside `tasks.json`:
 }
 ```
 
-- Edit Markdown.
-- Preview in VS Code.
-- Run the task and hand off the PPTX.
+- Edit Markdown with live Marp preview
+- Run the task when you're ready
+- Hand off the `.pptx`
+
+<!-- Speaker note: this is the workflow slide. Show that it fits naturally into a VS Code content authoring setup. -->
 
 ---
 
-## Release And Validation Narrative
+## Roadmap
 
-- Unit tests catch parser and renderer regressions.
-- **Invoke-PptxSmokeTest.ps1** and **Invoke-AllPptxSmokeTests.ps1** provide end-to-end local validation.
-- The validator project checks Open XML correctness.
-- PowerPoint open and round-trip save remain the final compatibility gate.
+- Broader CSS coverage for advanced Marp theme features
+- Smarter layout heuristics for dense or designed slides
+- Multi-layout template mapping
+- Improved table styling fidelity
+- Expanded syntax highlighting themes
+- Remote asset support
 
-The repo’s release workflow separates fast CI coverage from heavier release-gate validation.
-
----
-
-## Marp Themes And Authoring Conventions
-
-- Marp ships with built-in themes such as **default**, **gaia**, and **uncover**.
-- Directives are YAML-shaped, so front matter and HTML comments fit naturally into ordinary Markdown workflows.
-- Theme CSS stays readable and close to normal web styling, which keeps decks maintainable.
-- The same authoring approach works well for previews, automation, and source control review.
-
-That design discipline is a big reason MarpToPptx can map source intent into a more editable PowerPoint structure.
+<!-- Speaker note: be honest about where it's headed. The audience appreciates transparency about what's next. -->
 
 ---
 
-## Roadmap To Mention In The Q&A
+<!-- class: lead -->
+## Get Started
 
-- Improve CSS coverage for more Marp theme features.
-- Refine layout heuristics for denser or more designed decks.
-- Expand template integration to map multiple layouts more intelligently.
-- Improve native PPTX table styling and layout fidelity.
-- Expand code block highlighting coverage and theme fidelity.
-- Support remote assets and additional image formats.
+```bash
+dnx MarpToPptx slides.md -o slides.pptx
+```
 
-Closing point: MarpToPptx is for teams that want Markdown authoring discipline without giving up editable PowerPoint deliverables.
+**github.com/jongalloway/MarpToPptx**
 
-<!-- Closing note: end with the interoperability message. The tool matters because it lets Markdown-authored decks participate in ordinary Office collaboration. -->
+Keep writing in Markdown. Hand off a deck anyone can edit.
+
+<!-- Speaker note: close with the one-liner and the repo link. Invite questions. -->


### PR DESCRIPTION
## Summary

Rewrites project documentation for a marketing-first landing page and updates the showcase deck to match.

**Depends on #76** — merge that first, then retarget this PR to `main`.

## Changes

### README.md
- Rewritten as a landing page: problem/solution narrative, Marp ecosystem intro with links, workflow Mermaid diagram, Quick Start, Features table, VS Code integration, Sample Decks, Roadmap
- Added emojis to section headers

### CONTRIBUTING.md (new)
- Developer-focused content moved from README: repo structure, conventions, running from source, local packaging, cutting releases, reference doc links

### Showcase deck
- **08-showcase.md**: Rewritten as a 12-slide conference-style deck mirroring the README narrative
- **08-showcase.css**: Added `section.lead h2` color override for proper contrast on dark backgrounds
- Added `<!-- class: -->` resets to prevent directive carry-forward styling issues