### PR TITLE
Add helper script for creating and pushing release tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,14 @@ git tag v1.2.3
 git push origin v1.2.3
 ```
 
+Or use the helper script:
+
+```powershell
+pwsh ./scripts/New-ReleaseTag.ps1 -Version 1.2.3
+```
+
+The script requires a clean, up-to-date `main` branch and asks you to confirm that release validation is complete before it creates and pushes the tag. Use `-Force` only when you intentionally need to bypass those checks.
+
 After the workflow finishes and NuGet indexing completes, install or run the published tool with:
 
 ```bash

--- a/scripts/New-ReleaseTag.ps1
+++ b/scripts/New-ReleaseTag.ps1
@@ -1,0 +1,152 @@
+<#
+.SYNOPSIS
+    Prompts for a release version, normalizes it to a v-prefixed git tag, and pushes it.
+
+.DESCRIPTION
+    Accepts an optional version string, or prompts interactively when omitted.
+    If the supplied value does not begin with 'v', the script prepends it.
+    By default, the script requires a clean, up-to-date main branch and an
+    explicit acknowledgement that release validation is complete before it
+    creates and pushes an annotated git tag.
+
+.PARAMETER Version
+    Optional version or tag name. Examples: 1.0.0, v1.0.0, 1.0.0-rc.1.
+
+.PARAMETER Force
+    Bypass the branch, worktree, sync, and validation acknowledgement checks.
+
+.EXAMPLE
+    pwsh scripts/New-ReleaseTag.ps1
+
+.EXAMPLE
+    pwsh scripts/New-ReleaseTag.ps1 -Version 1.0.0-rc.1
+
+.EXAMPLE
+    pwsh scripts/New-ReleaseTag.ps1 -Version 1.0.0 -Force
+#>
+[CmdletBinding()]
+param(
+    [string]$Version,
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [switch]$AllowFailure
+    )
+
+    $output = & git @Arguments 2>&1
+    if (-not $AllowFailure -and $LASTEXITCODE -ne 0) {
+        $message = ($output | Out-String).Trim()
+        if ([string]::IsNullOrWhiteSpace($message)) {
+            $message = "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+        }
+        throw $message
+    }
+
+    return $output
+}
+
+function ConvertTo-TagName {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    $trimmed = $Value.Trim()
+    if ([string]::IsNullOrWhiteSpace($trimmed)) {
+        throw 'A version number is required.'
+    }
+
+    if ($trimmed.StartsWith('v', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return 'v' + $trimmed.Substring(1)
+    }
+
+    return 'v' + $trimmed
+}
+
+function Get-SingleGitOutput {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    return (Invoke-Git -Arguments $Arguments | Out-String).Trim()
+}
+
+$repoRoot = (Get-Item $PSScriptRoot).Parent.FullName
+Push-Location $repoRoot
+try {
+    $null = Invoke-Git -Arguments @('rev-parse', '--is-inside-work-tree')
+
+    if (-not $Force) {
+        $currentBranch = Get-SingleGitOutput -Arguments @('branch', '--show-current')
+        if ($currentBranch -ne 'main') {
+            throw "Release tags must be cut from main. Current branch: $currentBranch"
+        }
+
+        $statusOutput = Get-SingleGitOutput -Arguments @('status', '--porcelain')
+        if (-not [string]::IsNullOrWhiteSpace($statusOutput)) {
+            throw 'Working tree is not clean. Commit or stash changes before cutting a release tag.'
+        }
+
+        $null = Invoke-Git -Arguments @('fetch', 'origin', 'main', '--tags')
+
+        $headCommit = Get-SingleGitOutput -Arguments @('rev-parse', 'HEAD')
+        $originMainCommit = Get-SingleGitOutput -Arguments @('rev-parse', 'origin/main')
+        if ($headCommit -ne $originMainCommit) {
+            throw 'HEAD does not match origin/main. Pull or push the latest main branch state before cutting a release tag.'
+        }
+    }
+
+    if (-not $Version) {
+        $Version = Read-Host 'Enter release version (example: 1.0.0 or v1.0.0-rc.1)'
+    }
+
+    $tagName = ConvertTo-TagName -Value $Version
+
+    $localTag = Invoke-Git -Arguments @('tag', '--list', $tagName)
+    if (($localTag | Out-String).Trim()) {
+        throw "Tag already exists locally: $tagName"
+    }
+
+    $remoteTag = Invoke-Git -Arguments @('ls-remote', '--tags', 'origin', $tagName) -AllowFailure
+    if (($remoteTag | Out-String).Trim()) {
+        throw "Tag already exists on origin: $tagName"
+    }
+
+    Write-Host "Repository: $repoRoot"
+    Write-Host "Tag:        $tagName"
+
+    if (-not $Force) {
+        Write-Host ''
+        Write-Host 'Release validation reminder:'
+        Write-Host '  - Run the hosted Release Gate workflow.'
+        Write-Host '  - Complete the manual PowerPoint review in doc/release-validation.md.'
+
+        $validationConfirmation = Read-Host 'Type validated to confirm release validation is complete'
+        if ($validationConfirmation -cne 'validated') {
+            Write-Host 'Aborted. No tag was created.'
+            return
+        }
+    }
+
+    $confirmation = Read-Host 'Create and push this tag? [y/N]'
+    if ($confirmation -notmatch '^(y|yes)$') {
+        Write-Host 'Aborted. No tag was created.'
+        return
+    }
+
+    $null = Invoke-Git -Arguments @('tag', '-a', $tagName, '-m', "Release $tagName")
+    $null = Invoke-Git -Arguments @('push', 'origin', $tagName)
+
+    Write-Host "Created and pushed tag $tagName"
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
This pull request introduces a new PowerShell script to streamline the process of creating and pushing release tags, along with documentation updates to guide users on its usage. The script enforces validation checks to ensure releases are tagged from a clean, up-to-date `main` branch, and provides an option to bypass these checks if necessary.