### PR TITLE
chore: update GitHub Actions major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
           dotnet-version: 10.0.x
@@ -38,7 +38,7 @@ jobs:
         run: dotnet pack src/MarpToPptx.Cli/MarpToPptx.Cli.csproj --configuration Release --no-build
 
       - name: Upload Tool Package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: marp2pptx-nupkg
           path: artifacts/nupkg/*.nupkg
@@ -50,12 +50,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
           dotnet-version: 10.0.x
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload Smoke Test Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: marp2pptx-smoke-test-artifacts
           path: artifacts/smoke-tests/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
           dotnet-version: 10.0.x

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -21,12 +21,12 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                   global-json-file: global.json
                   dotnet-version: 10.0.x
@@ -128,7 +128,7 @@ jobs:
 
             - name: Upload Release Gate Artifacts
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: marp2pptx-release-gate-artifacts
                   path: |


### PR DESCRIPTION
## Summary
- update checkout from v4 to v6 in repo workflows
- update setup-dotnet from v4 to v5 in repo workflows
- update upload-artifact from v4 to v6 where used

## Validation
- verified workflow YAML structure after the edits
- did not run workflow jobs locally

## Notes
- VS Code still reports action-resolution errors for some valid actions in this repo, including existing references such as NuGet/login@v1; these appear to be editor resolver false positives rather than workflow syntax issues