### PR TITLE
chore: upgrade DiagramForge to 1.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="DiagramForge" Version="1.0.0" />
+    <PackageVersion Include="DiagramForge" Version="1.1.0" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.4.1" />
     <PackageVersion Include="Markdig" Version="1.1.1" />
     <PackageVersion Include="MinVer" Version="7.0.0" />

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There's just one hangup. When you're asked to turn in a PowerPoint deck at a con
 
 **That's where MarpToPptx comes in. 🎉** It reads your Marp-flavored Markdown and produces native Open XML PowerPoint files where every heading, bullet, table, and code block is a real, selectable, editable PowerPoint shape. The output opens cleanly in PowerPoint — no repair prompts, no surprises.
 
-> Diagram support: MarpToPptx renders both `mermaid` fences and `diagram` fences through [DiagramForge](https://github.com/jongalloway/DiagramForge), so Mermaid subsets plus conceptual layouts like matrix and pyramid can be embedded directly in your deck source.
+> Diagram support: MarpToPptx renders both `mermaid` fences and `diagram` fences through [DiagramForge](https://github.com/jongalloway/DiagramForge), so Mermaid subsets plus conceptual layouts like matrix, pyramid, funnel, and radial can be embedded directly in your deck source.
 
 ```mermaid
 flowchart LR

--- a/samples/09-diagrams.md
+++ b/samples/09-diagrams.md
@@ -221,3 +221,33 @@ pillars:
       - OpenAI
       - Search
 ```
+
+---
+
+## Conceptual Funnel
+
+Uses the deck-level `diagram-theme: prism`.
+
+```diagram
+diagram: funnel
+stages:
+  - Awareness
+  - Evaluation
+  - Conversion
+```
+
+---
+
+## Conceptual Radial
+
+Uses the deck-level `diagram-theme: prism`.
+
+```diagram
+diagram: radial
+center: Platform
+items:
+  - Security
+  - Reliability
+  - Observability
+  - Developer Experience
+```

--- a/samples/README.md
+++ b/samples/README.md
@@ -31,7 +31,7 @@ Dedicated smoke deck for presenter notes packaging, including note-bearing slide
 Speaker-style showcase deck generated from repo content, using `08-showcase.css` plus local Marp SVG assets to cover the Marp ecosystem, MarpToPptx capabilities, presenter notes, and the recommended VS Code task configuration.
 
 9. `09-diagrams.md`
-Diagram-focused sample deck that mixes Mermaid fences and `diagram` fences to exercise DiagramForge-backed flowchart, block, state, mindmap, matrix, and pyramid output with the companion `09-diagrams.css` theme.
+Diagram-focused sample deck that mixes Mermaid fences and `diagram` fences to exercise DiagramForge-backed flowchart, block, state, mindmap, matrix, pyramid, funnel, and radial output with the companion `09-diagrams.css` theme.
 
 ## Theme Decks
 

--- a/tests/MarpToPptx.Tests/PptxRendererTests.cs
+++ b/tests/MarpToPptx.Tests/PptxRendererTests.cs
@@ -5384,6 +5384,76 @@ public class PptxRendererTests
     }
 
     [Fact]
+    public void Renderer_DiagramFence_FunnelAndRadial_WithEmbeddedFrontMatter_RenderSvg()
+    {
+        using var workspace = TestWorkspace.Create();
+
+        var markdownPath = workspace.WriteMarkdown(
+            "deck.md",
+            """
+            # Funnel Diagram
+
+            ```diagram
+            ---
+            theme: presentation
+            ---
+            diagram: funnel
+            stages:
+              - Awareness
+              - Evaluation
+              - Conversion
+            ```
+
+            ---
+
+            # Radial Diagram
+
+            ```diagram
+            ---
+            theme: presentation
+            ---
+            diagram: radial
+            center: Platform
+            items:
+              - Security
+              - Reliability
+              - Observability
+              - Developer Experience
+            ```
+            """);
+
+        var outputPath = workspace.GetPath("deck.pptx");
+        RenderDeck(markdownPath, outputPath, workspace.RootPath);
+
+        using var document = PresentationDocument.Open(outputPath, false);
+        var slideParts = document.PresentationPart!.SlideParts.ToArray();
+        Assert.Equal(2, slideParts.Length);
+
+        foreach (var slidePart in slideParts)
+        {
+            var pictures = slidePart.Slide!.Descendants<P.Picture>().ToArray();
+            Assert.NotEmpty(pictures);
+
+            var svgPart = slidePart.ImageParts
+                .FirstOrDefault(p => string.Equals(p.ContentType, "image/svg+xml", StringComparison.OrdinalIgnoreCase));
+            Assert.NotNull(svgPart);
+
+            using var stream = svgPart!.GetStream();
+            var svg = new StreamReader(stream).ReadToEnd();
+            Assert.Contains("<svg", svg, StringComparison.OrdinalIgnoreCase);
+
+            var svgRelId = slidePart.GetIdOfPart(svgPart);
+            Assert.Contains(pictures, pic => pic.Descendants<DocumentFormat.OpenXml.Office2019.Drawing.SVG.SVGBlip>().Any(b => b.Embed?.Value == svgRelId));
+
+            var textRuns = slidePart.Slide.Descendants<A.Text>().Select(t => t.Text).ToArray();
+            Assert.DoesNotContain(textRuns, t => t.StartsWith("Diagram parse error:", StringComparison.Ordinal));
+        }
+
+        var validationErrors = new OpenXmlPackageValidator().Validate(document);
+        Assert.Empty(validationErrors);
+    }
+
+    [Fact]
     public void Renderer_DiagramFence_Pyramid_WithEmbeddedFrontMatter_RendersSvg()
     {
         // Real-world authored fence: pyramid diagram with embedded --- theme: presentation --- block.


### PR DESCRIPTION
## Summary
- bump DiagramForge from 1.0.0 to 1.1.0
- add regression coverage proving new funnel and radial conceptual diagrams render through the existing integration
- update sample and README text to expose the newly available diagram types
- extend the diagrams sample deck with funnel and radial examples

## Why
DiagramForge 1.1.0 adds new conceptual DSL layouts including funnel and radial. MarpToPptx already integrates through DiagramRenderer, so no renderer glue changes were needed beyond validation and discoverability updates.

## Validation
- dotnet restore MarpToPptx.slnx
- dotnet test --project tests/MarpToPptx.Tests/MarpToPptx.Tests.csproj -c Release --no-restore -- --filter-method "*Renderer_DiagramFence_FunnelAndRadial_WithEmbeddedFrontMatter_RenderSvg"
- pwsh ./scripts/Invoke-PptxSmokeTest.ps1 -InputMarkdown samples/09-diagrams.md -ThemeCss samples/09-diagrams.css -Configuration Release