### PR TITLE
fix: serialize TextMateSharp grammar loading to prevent thread-safety race

### DIFF
--- a/src/MarpToPptx.Pptx/Rendering/SyntaxHighlighter.cs
+++ b/src/MarpToPptx.Pptx/Rendering/SyntaxHighlighter.cs
@@ -37,6 +37,12 @@ public static class SyntaxHighlighter
     // Lazy so the registry is only initialised when syntax highlighting is first needed.
     private static readonly Lazy<HighlightState?> _state = new(CreateState);
 
+    // TextMateSharp's Registry/SyncRegistry is not thread-safe: concurrent
+    // LoadGrammar calls for the same scope can race on Dictionary.Add and
+    // throw "An item with the same key has already been added". Serialize
+    // grammar loading through this lock.
+    private static readonly object _grammarLock = new();
+
     /// <summary>Returns <c>true</c> when <paramref name="language"/> has grammar support.</summary>
     public static bool IsSupported(string? language)
     {
@@ -69,7 +75,11 @@ public static class SyntaxHighlighter
             var scopeName = state.Options.GetScopeByLanguageId(canonicalId);
             if (scopeName is not null)
             {
-                var grammar = state.Registry.LoadGrammar(scopeName);
+                IGrammar? grammar;
+                lock (_grammarLock)
+                {
+                    grammar = state.Registry.LoadGrammar(scopeName);
+                }
                 if (grammar is not null)
                 {
                     return TokenizeWithGrammar(code, grammar, state.Theme);


### PR DESCRIPTION
Fixes an intermittent CI failure in `Extractor_InfersCodeBlockFromCodeLikeText_WhenShapeNameIsGeneric` caused by a thread-safety race in TextMateSharp's `SyncRegistry`.

## Root cause

TextMateSharp's `SyncRegistry.AddGrammar()` uses `Dictionary.Add()` which is not thread-safe. The `Registry` instance is a process-wide singleton (via `Lazy<>`), and when xUnit runs tests in parallel, two tests can call `Registry.LoadGrammar("source.cs")` concurrently. The second call tries to `Add` the same key the first is still inserting, throwing:

> `System.ArgumentException: An item with the same key has already been added. Key: source.cs`

## Fix

Add a `lock` around `Registry.LoadGrammar()` in `SyntaxHighlighter.Tokenize()`. Once a grammar is loaded, subsequent calls return the cached instance without entering `AddGrammar`, so the lock has zero steady-state contention.

## Evidence

- Failure: https://github.com/jongalloway/MarpToPptx/actions/runs/24006380689/job/70010669243
- Rerun with no changes passed (classic thread-safety flake)
- 434/434 tests pass locally after fix